### PR TITLE
Change pin reading algorithm to use regexes

### DIFF
--- a/connect/src/com/telenor/connect/sms/SmsPinParseUtil.java
+++ b/connect/src/com/telenor/connect/sms/SmsPinParseUtil.java
@@ -1,37 +1,37 @@
 package com.telenor.connect.sms;
 
+import com.telenor.connect.ui.Instruction;
+
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class SmsPinParseUtil {
 
-    private static final String TEMPLATE_TO_MATCH
-            = "(?: (\\d+) .*(?:Connect|CONNECT).*)|(?:.*(?:Connect|CONNECT).* (\\d+) )"
-            + "|(?:.*(?:Connect|CONNECT).* (\\d+)$)|(?:^(\\d+) .*(?:Connect|CONNECT).*)";
+    private static final String MUST_CONTAIN = "CONNECT";
 
-    public static String findPin(String body) {
-        Pattern patternToMatch = Pattern.compile(TEMPLATE_TO_MATCH);
-        Matcher matcher = patternToMatch.matcher(body);
-        if (!matcher.find()) {
+    public static String findPin(String body, Instruction instruction) {
+        if (body == null || body.isEmpty() || !body.contains(MUST_CONTAIN)) {
             return null;
         }
 
-        for (int i = 0; i < matcher.groupCount(); i++) {
-            String group = matcher.group(i);
-            if (isNumber(group)) {
-                return group;
+        List<Object> patterns = instruction.getArguments();
+
+        for (Object pattern: patterns) {
+            if (!(pattern instanceof String)) {
+                continue;
             }
+            String p = (String) pattern;
+
+            Pattern patternToMatch = Pattern.compile(p);
+            Matcher matcher = patternToMatch.matcher(body);
+            if (!matcher.find()) {
+                continue;
+            }
+
+            return matcher.group(1);
         }
 
-        throw new RuntimeException("Found match, but then couldn't find it.");
-    }
-
-    private static boolean isNumber(String s) {
-        try {
-            Integer.parseInt(s);
-            return true;
-        } catch (NumberFormatException e) {
-            return false;
-        }
+        return null;
     }
 }

--- a/connect/src/com/telenor/connect/sms/SmsPinParseUtil.java
+++ b/connect/src/com/telenor/connect/sms/SmsPinParseUtil.java
@@ -2,28 +2,23 @@ package com.telenor.connect.sms;
 
 import com.telenor.connect.ui.Instruction;
 
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class SmsPinParseUtil {
 
     private static final String MUST_CONTAIN = "CONNECT";
+    // For security reasons all SMS that are going to be checked for PIN codes needs to be
+    // checked for the keyword `CONNECT`. Otherwise a malicious person might use a regex that
+    // grabs the entire sms, from all senders.
 
     public static String findPin(String body, Instruction instruction) {
         if (body == null || body.isEmpty() || !body.contains(MUST_CONTAIN)) {
             return null;
         }
 
-        List<Object> patterns = instruction.getArguments();
-
-        for (Object pattern: patterns) {
-            if (!(pattern instanceof String)) {
-                continue;
-            }
-            String p = (String) pattern;
-
-            Pattern patternToMatch = Pattern.compile(p);
+        for (Object pattern: instruction.getArguments()) {
+            Pattern patternToMatch = Pattern.compile((String) pattern);
             Matcher matcher = patternToMatch.matcher(body);
             if (!matcher.find()) {
                 continue;
@@ -31,7 +26,6 @@ public class SmsPinParseUtil {
 
             return matcher.group(1);
         }
-
         return null;
     }
 }

--- a/connect/src/com/telenor/connect/ui/ConnectWebViewClient.java
+++ b/connect/src/com/telenor/connect/ui/ConnectWebViewClient.java
@@ -243,7 +243,7 @@ public class ConnectWebViewClient extends WebViewClient implements SmsHandler, I
     }
 
     private void handlePinFromSmsBodyIfPresent(String body, final Instruction instruction) {
-        final String foundPin = SmsPinParseUtil.findPin(body);
+        final String foundPin = SmsPinParseUtil.findPin(body, instruction);
         if (foundPin != null && instruction.getPinCallbackName() != null) {
             stopGetPin();
             webView.post(new Runnable() {

--- a/connect/src/com/telenor/connect/ui/Instruction.java
+++ b/connect/src/com/telenor/connect/ui/Instruction.java
@@ -43,7 +43,10 @@ public class Instruction {
     }
 
     public boolean isValidPinInstruction() {
-        return name != null && name.equals(Instruction.PIN_INSTRUCTION_NAME);
+        return name != null
+                && name.equals(Instruction.PIN_INSTRUCTION_NAME)
+                && arguments != null
+                && !arguments.isEmpty();
     }
 
     @Override

--- a/connect/tests/src/test/java/com/telenor/connect/sms/HtmlToAndroidInstructionsInterfaceTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/sms/HtmlToAndroidInstructionsInterfaceTest.java
@@ -24,7 +24,7 @@ public class HtmlToAndroidInstructionsInterfaceTest {
             "  {  \n" +
             "    \"name\":\"eval\",\n" +
             "    \"arguments\":[  \n" +
-            "      \"\\\"$('#pin').attr('placeholder', 'Waiting for PIN on SMS…');\\\"\"\n" +
+            "      \"\\\"$('#pin').attr('placeholder', 'Waiting for PIN on SMS...');\\\"\"\n" +
             "    ]\n" +
             "  },\n" +
             "  {  \n" +
@@ -35,7 +35,12 @@ public class HtmlToAndroidInstructionsInterfaceTest {
             "  },\n" +
             "  {  \n" +
             "    \"name\":\"androidSystemCall_getPinFromSms\",\n" +
-            "    \"pin_callback_name\":\"handlePinReceived\"\n" +
+            "    \"pin_callback_name\":\"handlePinReceived\",\n" +
+            "    \"arguments\":[  \n" +
+            "      \"(?:.* ([0-9]{4}) .*)\",\n" +
+            "      \"(?:.* ([0-9]{4})$)\",\n" +
+            "      \"(?:^([0-9]{4}) )\"\n" +
+            "    ]\n" +
             "  }\n" +
             "]";
 
@@ -54,16 +59,17 @@ public class HtmlToAndroidInstructionsInterfaceTest {
             "  }" +
             "]";
 
-    private static final String missingDoubleQuotesOnVarsJson = "[  \n" +
-            "   {  \n" +
+    private static final String missingDoubleQuotesOnVarsJson = "[\n" +
+            "   {\n" +
             "      name:\"androidJsCall_waitForSmsWithTimeout\"\n" +
             "   },\n" +
-            "   {  \n" +
+            "   {\n" +
             "      name:\"androidJsCall_handlePinReceived\"\n" +
             "   },\n" +
-            "   {  \n" +
+            "   {\n" +
             "      name:\"androidSystemCall_getPinFromSms\",\n" +
-            "      pin_callback_name:\"androidJsCall_handlePinReceived\"\n" +
+            "      pin_callback_name:\"androidJsCall_handlePinReceived\",\n" +
+            "      arguments: [\"some arg\"]\n" +
             "   }\n" +
             "]";
 
@@ -143,7 +149,7 @@ public class HtmlToAndroidInstructionsInterfaceTest {
         Instruction showLoading = new Instruction();
         showLoading.setName("eval");
         ArrayList<Object> showLoadingArguments = new ArrayList<>();
-        showLoadingArguments.add("\"$('#pin').attr('placeholder', 'Waiting for PIN on SMS…');\"");
+        showLoadingArguments.add("\"$('#pin').attr('placeholder', 'Waiting for PIN on SMS...');\"");
         showLoading.setArguments(showLoadingArguments);
         instructions.add(showLoading);
 
@@ -158,6 +164,11 @@ public class HtmlToAndroidInstructionsInterfaceTest {
         Instruction getPinFromSms = new Instruction();
         getPinFromSms.setName("androidSystemCall_getPinFromSms");
         getPinFromSms.setPinCallbackName("handlePinReceived");
+        List<Object> list = new ArrayList<>();
+        list.add("(?:.* ([0-9]{4}) .*)");
+        list.add("(?:.* ([0-9]{4})$)");
+        list.add("(?:^([0-9]{4}) )");
+        getPinFromSms.setArguments(list);
         instructions.add(getPinFromSms);
 
         return instructions;

--- a/connect/tests/src/test/java/com/telenor/connect/sms/SmsPinParseUtilTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/sms/SmsPinParseUtilTest.java
@@ -1,6 +1,13 @@
 package com.telenor.connect.sms;
 
+import android.support.annotation.NonNull;
+
+import com.telenor.connect.ui.Instruction;
+
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static junit.framework.Assert.assertNull;
 import static org.hamcrest.CoreMatchers.is;
@@ -11,97 +18,122 @@ public class SmsPinParseUtilTest {
 
     @Test
     public void findsPinInEnglishSms() {
+        final Instruction instruction = get4DigitPinInstruction();
         String body = "Your verification code for ''HipstaGram'' is 3456 - CONNECT by Telenor Digital.";
-        String actual = SmsPinParseUtil.findPin(body);
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertThat(actual, is("3456"));
+    }
+
+    @NonNull
+    private Instruction get4DigitPinInstruction() {
+        final Instruction instruction = new Instruction();
+        instruction.setName(Instruction.PIN_INSTRUCTION_NAME);
+        List<Object> list = new ArrayList<>();
+        list.add("(?:.* ([0-9]{4}) .*)");
+        list.add("(?:.* ([0-9]{4})$)");
+        list.add("(?:^([0-9]{4}) )");
+        instruction.setArguments(list);
+        return instruction;
     }
 
     @Test
     public void findsPinInJumbledEnglishSms() {
+        final Instruction instruction = get4DigitPinInstruction();
         String body = "CONNECT by Telenor Digital: Your verification code for ''HipstaGram'' is 3456";
-        String actual = SmsPinParseUtil.findPin(body);
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertThat(actual, is("3456"));
     }
 
     @Test
     public void findsPinInCaptureBrandedSms() {
+        final Instruction instruction = get4DigitPinInstruction();
         String body = "Capture: 3456 is your verification code for CONNECT";
-        String actual = SmsPinParseUtil.findPin(body);
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertThat(actual, is("3456"));
     }
 
     @Test
     public void findsPinInUnbrandedSms() {
-        String body = "Your verification code is 0102 - Connect by Telenor Digital";
-        String actual = SmsPinParseUtil.findPin(body);
+        final Instruction instruction = get4DigitPinInstruction();
+        String body = "Your verification code is 0102 - CONNECT by Telenor Digital";
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertThat(actual, is("0102"));
     }
 
     @Test
     public void findsPinInPrefixedUnbrandedSms() {
-        String body = "RM0.00 Your verification code is 0102 - Connect by Telenor Digital";
-        String actual = SmsPinParseUtil.findPin(body);
+        final Instruction instruction = get4DigitPinInstruction();
+        String body = "RM0.00 Your verification code is 0102 - CONNECT by Telenor Digital";
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertThat(actual, is("0102"));
     }
 
     @Test
     public void findsPinInPrefixedCaptureBrandedSms() {
+        final Instruction instruction = get4DigitPinInstruction();
         String body = "RM0.00 Capture: 0022 is your verification code for CONNECT";
-        String actual = SmsPinParseUtil.findPin(body);
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertThat(actual, is("0022"));
     }
 
     @Test
-    public void pinWithoutConnectInItReturnsNull() {
+    public void pinWithoutCONNECTInItReturnsNull() {
+        final Instruction instruction = get4DigitPinInstruction();
         String body = "Google: 0022 is your verification code";
-        String actual = SmsPinParseUtil.findPin(body);
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertThat(actual, is(nullValue()));
     }
 
     @Test
     public void smsWithNonMatchingPatternReturnsNull() {
+        final Instruction instruction = get4DigitPinInstruction();
         String body = "RM0.00 Hi. Please click on the link below to change " +
-                "your Connect password: https://s.telenordigital.com/abcde";
-        String actual = SmsPinParseUtil.findPin(body);
+                "your CONNECT password: https://s.telenordigital.com/abcde";
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertThat(actual, is(nullValue()));
     }
 
     @Test
     public void findsPinInThaiSms() {
+        final Instruction instruction = get4DigitPinInstruction();
         String body = "\u0e23\u0e2b\u0e31\u0e2a\u0e22\u0e37\u0e19\u0e22\u0e31\u0e19\u0e02\u0e2d\u0e07\u0e04\u0e38\u0e13\u0e2a\u0e33\u0e2b\u0e23\u0e31\u0e1a ''HipstaGram'' \u0e04\u0e37\u0e2d 3456 - CONNECT \u0e42\u0e14\u0e22 Telenor Digital";
         // same as: "รหัสยืนยันของคุณสำหรับ ''HipstaGram'' คือ 3456 - CONNECT โดย Telenor Digital";
-        String actual = SmsPinParseUtil.findPin(body);
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertThat(actual, is("3456"));
     }
 
     @Test
     public void lookingForMissingPinInEnglishSmsReturnsNull() {
+        final Instruction instruction = get4DigitPinInstruction();
         String body = "Telenor are currently having connectivity issues. Expected fix time" +
                 " is by 20:00 tonight.";
-        String actual = SmsPinParseUtil.findPin(body);
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertNull(actual);
     }
 
     @Test
     public void lookingForMissingPinInThaiSmsReturnsNull() {
+        final Instruction instruction = get4DigitPinInstruction();
         String body = "\u0e23\u0e2b\u0e31\u0e2a\u0e22\u0e37\u0e19\u0e22\u0e31\u0e19\u0e02\u0e2d\u0e07\u0e04\u0e38\u0e13\u0e2a\u0e33\u0e2b\u0e23\u0e31\u0e1a \u0e04\u0e37\u0e2d  - CONNECT \u0e42\u0e14\u0e22 Telenor Digital";
         // same as: "รหัสยืนยันของคุณสำหรับ คือ  - CONNECT โดย Telenor Digital"
-        String actual = SmsPinParseUtil.findPin(body);
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertNull(actual);
     }
 
     @Test
     public void findsPinInRightToLeftLanguages() {
+        final Instruction instruction = get4DigitPinInstruction();
         String body = "''Hipstagram'' \u06a9\u06d2 \u0644\u06cc\u06d2 \u0627\u0653\u067e \u06a9\u0627 \u062a\u0635\u062f\u06cc\u0642\u06cc \u06a9\u0648\u0688 3456 \u06c1\u06d2 - Telenor Digital \u06a9\u0627 \u067e\u06cc\u0634 \u06a9\u0631\u062f\u06c1 CONNECT\u06d4";
         // ''Hipstagram'' کے لیے آپ کا تصدیقی کوڈ 3456 ہے - Telenor Digital کا پیش کردہ CONNECT۔
-        String actual = SmsPinParseUtil.findPin(body);
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertThat(actual, is("3456"));
     }
 
     @Test
     public void lookingForMissingPinInRightToLeftLanguageReturnsNull() {
+        final Instruction instruction = get4DigitPinInstruction();
         String body = "\u0627\u0653\u067e \u0646\u06d2 \u063a\u0644\u0637 \u067e\u0627\u0633 \u0648\u0631\u0688 \u062f\u0631\u062c \u06a9\u06cc\u0627 \u06c1\u06d2\u06d4 \u0628\u0631\u0627\u06c1\u0650 \u0645\u06c1\u0631\u0628\u0627\u0646\u06cc \u062f\u0648\u0628\u0627\u0631\u06c1 \u06a9\u0648\u0634\u0634 \u06a9\u0631\u06cc\u06ba \u06cc\u0627 <a href=\"{0}\">\u0627\u067e\u0646\u0627 \u067e\u0627\u0633 \u0648\u0631\u0688 \u062f\u0648\u0628\u0627\u0631\u06c1 \u062a\u0631\u062a\u06cc\u0628 \u062f\u06cc\u06ba</a>\u06d4";
-        String actual = SmsPinParseUtil.findPin(body);
+        String actual = SmsPinParseUtil.findPin(body, instruction);
         assertNull(actual);
     }
 }


### PR DESCRIPTION
Change pin reading algorithm to use regexes from Android instructions on page.
Pin's must still contain `CONNECT` in order to be evaluated.