### PR TITLE
Fix reading of already received sms race condition

### DIFF
--- a/connect/src/com/telenor/connect/ui/ConnectWebViewClient.java
+++ b/connect/src/com/telenor/connect/ui/ConnectWebViewClient.java
@@ -243,9 +243,9 @@ public class ConnectWebViewClient extends WebViewClient implements SmsHandler, I
         }, RACE_CONDITION_DELAY_CHECK_ALREADY_RECEIVED_SMS);
     }
 
-    private void handlePinFromSmsBodyIfPresent(String body, final Instruction instruction) {
+    private synchronized void handlePinFromSmsBodyIfPresent(String body, final Instruction instruction) {
         final String foundPin = SmsPinParseUtil.findPin(body, instruction);
-        if (foundPin != null && instruction.getPinCallbackName() != null) {
+        if (waitingForPinSms && foundPin != null && instruction.getPinCallbackName() != null) {
             stopGetPin();
             webView.post(new Runnable() {
                 @Override


### PR DESCRIPTION
On Android M, accepting sms permissions to autofill pin from already
received sms, after already receiving an sms, would trigger a race
condition. This commit fixes this.