### PR TITLE
Allow HE to be tried based on mcc/mnc information

### DIFF
--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -8,7 +8,9 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.telephony.TelephonyManager;
 import android.text.TextUtils;
+import android.webkit.CookieManager;
 
 import com.squareup.okhttp.HttpUrl;
 import com.telenor.connect.id.AccessTokenCallback;
@@ -304,6 +306,20 @@ public final class ConnectSdk {
                 RestHelper.getConnectApi(getConnectApiUrl().toString()),
                 sClientId,
                 sRedirectUri);
+    }
+
+    public static String getMccMnc() {
+        TelephonyManager tel
+                = (TelephonyManager)getContext().getSystemService(Context.TELEPHONY_SERVICE);
+        return tel.getNetworkOperator();
+    }
+
+    public static String getMccMncLoginHint() {
+        String mccMnc = getMccMnc();
+        if (mccMnc.isEmpty()) {
+            return null;
+        }
+        return String.format("MCCMNC:%s", mccMnc);
     }
 
     public static void setLocales(Locale... locales) {

--- a/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
@@ -107,6 +107,11 @@ public class ConnectLoginButton extends ConnectButton {
                 parameters.put("scope", TextUtils.join(" ", getLoginScopeTokens()));
             }
 
+            final String mccMncLoginHint = ConnectSdk.getMccMncLoginHint();
+            if (mccMncLoginHint != null) {
+                parameters.put("login_hint", mccMncLoginHint);
+            }
+
             if (claims != null && claims.getClaimsAsSet() != null) {
                 try {
                     parameters.put("claims", ClaimsParameterFormatter.asJson(claims));


### PR DESCRIPTION
Jira: MC-1556

HE service is being extended to support Force HE over WiFi. For the
purpose we need to support HE flows started based on the MCC/MNC
passed by the device to the authorization endpoint.

See design doc at
https://confluence.skunk-works.no/confluence/x/30BRAg.