### PR TITLE
Forced HE over WiFi

### DIFF
--- a/connect-id-example/src/main/AndroidManifest.xml
+++ b/connect-id-example/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.telenor.connect.connectidexample" >
 
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
     <uses-permission android:name="android.permission.READ_SMS" />

--- a/connect/src/com/telenor/connect/WellKnownAPI.java
+++ b/connect/src/com/telenor/connect/WellKnownAPI.java
@@ -2,6 +2,7 @@ package com.telenor.connect;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Set;
 import retrofit.Callback;
 import retrofit.http.GET;
 import retrofit.http.Headers;
@@ -17,9 +18,14 @@ public interface WellKnownAPI {
     class WellKnownConfig {
         @SerializedName("issuer")
         private String issuer;
-
         public String getIssuer() {
             return issuer;
+        }
+
+        @SerializedName("network_authentication_target_ips")
+        private Set<String> networkAuthenticationTargetIps;
+        public Set<String> getNetworkAuthenticationTargetIps() {
+            return networkAuthenticationTargetIps;
         }
     }
 }

--- a/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
@@ -107,6 +107,11 @@ public class ConnectLoginButton extends ConnectButton {
                 parameters.put("scope", TextUtils.join(" ", getLoginScopeTokens()));
             }
 
+            final String mccMnc = ConnectSdk.getMccMnc();
+            if (mccMnc != null) {
+                parameters.put("login_hint", String.format("MCCMNC:%s", mccMnc));
+            }
+
             if (claims != null && claims.getClaimsAsSet() != null) {
                 try {
                     parameters.put("claims", ClaimsParameterFormatter.asJson(claims));

--- a/mobileconnect-example/src/main/AndroidManifest.xml
+++ b/mobileconnect-example/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.telenor.connect.mobileconnectexample" >
 
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
     <uses-permission android:name="android.permission.READ_SMS" />


### PR DESCRIPTION
Add the possibility to execute request towards specific IPs found from
the .well-known configuration API using the cellular network interface, thus
achieving successful HE ,even when both WiFi and cellular are on.

For more information, see design doc at:
https://confluence.skunk-works.no/confluence/x/30BRAg.