### PR TITLE
Add operator selection to Mobile Connect authentication flow

### DIFF
--- a/connect/src/com/telenor/connect/AbstractSdkProfile.java
+++ b/connect/src/com/telenor/connect/AbstractSdkProfile.java
@@ -2,12 +2,14 @@ package com.telenor.connect;
 
 import android.content.Context;
 import android.net.Uri;
+import android.text.TextUtils;
 
 import com.telenor.connect.id.ConnectIdService;
 import com.telenor.connect.utils.RestHelper;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import retrofit.Callback;
 import retrofit.RetrofitError;
@@ -107,6 +109,11 @@ public abstract class AbstractSdkProfile implements SdkProfile {
         if (parameters.get("scope") == null || parameters.get("scope").isEmpty()) {
             throw new IllegalStateException("Cannot log in without scope tokens.");
         }
+
+        if (TextUtils.isEmpty(parameters.get("state"))) {
+            parameters.put("state", UUID.randomUUID().toString());
+        }
+
         return getAuthorizeUri(parameters, uiLocales);
     }
 }

--- a/connect/src/com/telenor/connect/AbstractSdkProfile.java
+++ b/connect/src/com/telenor/connect/AbstractSdkProfile.java
@@ -17,8 +17,8 @@ import retrofit.client.Response;
 
 public abstract class AbstractSdkProfile implements SdkProfile {
 
-    private volatile ConnectIdService connectIdService;
-    private volatile WellKnownAPI.WellKnownConfig wellKnownConfig;
+    private ConnectIdService connectIdService;
+    private WellKnownAPI.WellKnownConfig wellKnownConfig;
 
     protected Context context;
     protected boolean confidentialClient;
@@ -96,7 +96,7 @@ public abstract class AbstractSdkProfile implements SdkProfile {
                 });
     }
 
-    protected synchronized Uri getAuthorizationStartUri(
+    protected Uri getAuthorizationStartUri(
             Map<String, String> parameters,
             List<String> uiLocales) {
         if (getClientId() == null) {

--- a/connect/src/com/telenor/connect/AbstractSdkProfile.java
+++ b/connect/src/com/telenor/connect/AbstractSdkProfile.java
@@ -1,12 +1,13 @@
 package com.telenor.connect;
 
 import android.content.Context;
+import android.net.Uri;
 
 import com.telenor.connect.id.ConnectIdService;
 import com.telenor.connect.utils.RestHelper;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.List;
+import java.util.Map;
 
 import retrofit.Callback;
 import retrofit.RetrofitError;
@@ -66,9 +67,12 @@ public abstract class AbstractSdkProfile implements SdkProfile {
         wellKnownConfig = null;
     }
 
-    protected void initializeAndContinueAuthorizationFlow(final OnStartAuthorizationCallback callback) {
+    protected void initializeAndContinueAuthorizationFlow(
+            final Map<String, String> parameters,
+            final List<String> uiLocales,
+            final OnDeliverAuthorizationUriCallback callback) {
         if (isInitialized) {
-            callback.onSuccess();
+            callback.onSuccess(getAuthorizationStartUri(parameters, uiLocales));
             return;
         }
         RestHelper.
@@ -78,15 +82,31 @@ public abstract class AbstractSdkProfile implements SdkProfile {
                     public void success(WellKnownAPI.WellKnownConfig config, Response response) {
                         wellKnownConfig = config;
                         isInitialized = true;
-                        callback.onSuccess();
+                        callback.onSuccess(getAuthorizationStartUri(parameters, uiLocales));
                     }
 
                     @Override
                     public void failure(RetrofitError error) {
                         wellKnownConfig = null;
                         isInitialized = true;
-                        callback.onSuccess();
+                        callback.onSuccess(getAuthorizationStartUri(parameters, uiLocales));
                     }
                 });
+    }
+
+    protected synchronized Uri getAuthorizationStartUri(
+            Map<String, String> parameters,
+            List<String> uiLocales) {
+        if (getClientId() == null) {
+            throw new ConnectException("Client ID not specified in application manifest.");
+        }
+        if (getRedirectUri() == null) {
+            throw new ConnectException("Redirect URI not specified in application manifest.");
+        }
+
+        if (parameters.get("scope") == null || parameters.get("scope").isEmpty()) {
+            throw new IllegalStateException("Cannot log in without scope tokens.");
+        }
+        return getAuthorizeUri(parameters, uiLocales);
     }
 }

--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -160,9 +160,6 @@ public final class ConnectSdk {
                             Uri startUri,
                             boolean isDivertedToFetchInitUri) {
 
-                        if (TextUtils.isEmpty(parameters.get("state"))) {
-                            parameters.put("state", UUID.randomUUID().toString());
-                        }
                         sLastAuthState = parameters.get("state");
 
                         Intent intent = getAuthIntent(startUri);

--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -163,6 +163,9 @@ public final class ConnectSdk {
                         sLastAuthState = parameters.get("state");
 
                         Intent intent = getAuthIntent(startUri);
+                        intent.putExtra(
+                                ConnectUtils.WELL_KNOWN_CONFIG_EXTRA,
+                                sdkProfile.getWellKnownConfig());
 
                         if (isDivertedToFetchInitUri) {
                             intent.putExtra(

--- a/connect/src/com/telenor/connect/ConnectSdkProfile.java
+++ b/connect/src/com/telenor/connect/ConnectSdkProfile.java
@@ -81,8 +81,11 @@ public class ConnectSdkProfile extends AbstractSdkProfile {
     }
 
     @Override
-    public void onStartAuthorization(OnStartAuthorizationCallback callback) {
-        initializeAndContinueAuthorizationFlow(callback);
+    public void onStartAuthorization(
+            Map<String, String> parameters,
+            List<String> locales,
+            OnStartAuthorizationCallback callback) {
+        initializeAndContinueAuthorizationFlow(parameters, locales, callback);
     }
 
     @Override
@@ -123,5 +126,14 @@ public class ConnectSdkProfile extends AbstractSdkProfile {
             return endpoint;
         }
         return endpoint.replace("connect.telenordigital.com", "connect.staging.telenordigital.com");
+    }
+
+    @Override
+    public void initializeFromUri(
+            Map<String, String> parameters,
+            List<String> uiLocales,
+            Uri initFrom,
+            OnDeliverAuthorizationUriCallback callback) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/connect/src/com/telenor/connect/SdkProfile.java
+++ b/connect/src/com/telenor/connect/SdkProfile.java
@@ -24,10 +24,23 @@ public interface SdkProfile {
     WellKnownAPI.WellKnownConfig getWellKnownConfig();
     boolean isInitialized();
 
-    void onStartAuthorization(OnStartAuthorizationCallback callback);
+    void initializeFromUri(
+            Map<String, String> parameters,
+            List<String> uiLocales,
+            Uri initFrom,
+            OnDeliverAuthorizationUriCallback callback);
 
-    interface OnStartAuthorizationCallback {
-        void onSuccess();
+    void onStartAuthorization(
+            Map<String, String> parameters,
+            List<String> uiLocales,
+            OnStartAuthorizationCallback callback);
+
+    interface OnDeliverAuthorizationUriCallback {
+        void onSuccess(Uri authorizationStartUri);
         void onError();
+    }
+
+    interface OnStartAuthorizationCallback extends OnDeliverAuthorizationUriCallback {
+        void onDivert(Uri diversionUri);
     }
 }

--- a/connect/src/com/telenor/connect/WellKnownAPI.java
+++ b/connect/src/com/telenor/connect/WellKnownAPI.java
@@ -2,6 +2,7 @@ package com.telenor.connect;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.io.Serializable;
 import java.util.Set;
 
 import retrofit.Callback;
@@ -16,7 +17,7 @@ public interface WellKnownAPI {
     @GET("/")
     void getWellKnownConfig(Callback<WellKnownConfig> callback);
 
-    class WellKnownConfig {
+    class WellKnownConfig implements Serializable {
         @SerializedName("issuer")
         private String issuer;
         public String getIssuer() {

--- a/connect/src/com/telenor/connect/WellKnownAPI.java
+++ b/connect/src/com/telenor/connect/WellKnownAPI.java
@@ -3,6 +3,7 @@ package com.telenor.connect;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Set;
+
 import retrofit.Callback;
 import retrofit.http.GET;
 import retrofit.http.Headers;

--- a/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
@@ -21,14 +21,12 @@ import java.util.Map;
 
 public class ConnectLoginButton extends ConnectButton {
 
-    private static final int NO_CUSTOM_LAYOUT = -1;
-
     private ArrayList<String> acrValues;
     private Map<String, String> loginParameters;
     private ArrayList<String> loginScopeTokens;
     private int requestCode = 0xa987;
     private Claims claims;
-    private int customLoadingLayout = NO_CUSTOM_LAYOUT;
+    private int customLoadingLayout = ConnectSdk.NO_CUSTOM_LAYOUT;
 
     public ConnectLoginButton(Context context, AttributeSet attributeSet) {
         super(context, attributeSet);
@@ -124,14 +122,10 @@ public class ConnectLoginButton extends ConnectButton {
                 parameters.putAll(getLoginParameters());
             }
 
-            if (customLoadingLayout == NO_CUSTOM_LAYOUT) {
-                ConnectSdk.authenticate(getActivity(), parameters, requestCode);
-            } else {
-                ConnectSdk.authenticate(getActivity(),
-                        parameters,
-                        customLoadingLayout,
-                        requestCode);
-            }
+            ConnectSdk.authenticate(getActivity(),
+                    parameters,
+                    customLoadingLayout,
+                    requestCode);
         }
     }
 }

--- a/connect/src/com/telenor/connect/utils/ConnectUrlHelper.java
+++ b/connect/src/com/telenor/connect/utils/ConnectUrlHelper.java
@@ -7,11 +7,7 @@ import android.text.TextUtils;
 
 import com.squareup.okhttp.HttpUrl;
 import com.telenor.connect.BuildConfig;
-import com.telenor.connect.ConnectSdk;
-import com.telenor.connect.ConnectSdkProfile;
-import com.telenor.mobileconnect.MobileConnectSdkProfile;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/connect/src/com/telenor/connect/utils/ConnectUtils.java
+++ b/connect/src/com/telenor/connect/utils/ConnectUtils.java
@@ -18,6 +18,10 @@ public class ConnectUtils {
     public static final String PAYMENT_ACTION = "com.telenor.connect.PAYMENT_ACTION";
     public static final String CUSTOM_LOADING_SCREEN_EXTRA
             = "com.telenor.connect.CUSTOM_LOADING_SCREEN_EXTRA";
+    public static final String IS_DIVERTED_TO_FETCH_INIT_URI
+            = "com.telenor.connect.IS_DIVERTED_TO_FETCH_INIT_URI";
+    public static final String PARAM_SNAPHOT_EXTRA = "com.telenor.connect.PARAM_SNAPSHOT";
+    public static final String UI_LOCALES_SNAPHOT_EXTRA = "com.telenor.connect.UI_LOCALES_SNAPSHOT";
 
     public static void parseAuthCode(String callbackUrl, ConnectCallback callback) {
         Validator.notNullOrEmpty(callbackUrl, "callbackUrl");

--- a/connect/src/com/telenor/connect/utils/ConnectUtils.java
+++ b/connect/src/com/telenor/connect/utils/ConnectUtils.java
@@ -22,6 +22,8 @@ public class ConnectUtils {
             = "com.telenor.connect.IS_DIVERTED_TO_FETCH_INIT_URI";
     public static final String PARAM_SNAPHOT_EXTRA = "com.telenor.connect.PARAM_SNAPSHOT";
     public static final String UI_LOCALES_SNAPHOT_EXTRA = "com.telenor.connect.UI_LOCALES_SNAPSHOT";
+    public static final String WELL_KNOWN_CONFIG_EXTRA
+            = "com.telenor.connect.WELL_KNOWN_CONFIG_EXTRA";
 
     public static void parseAuthCode(String callbackUrl, ConnectCallback callback) {
         Validator.notNullOrEmpty(callbackUrl, "callbackUrl");

--- a/connect/src/com/telenor/connect/utils/JavascriptUtil.java
+++ b/connect/src/com/telenor/connect/utils/JavascriptUtil.java
@@ -1,6 +1,7 @@
 package com.telenor.connect.utils;
 
 import android.text.TextUtils;
+
 import com.telenor.connect.ui.Instruction;
 
 import java.util.List;

--- a/connect/src/com/telenor/connect/utils/RestHelper.java
+++ b/connect/src/com/telenor/connect/utils/RestHelper.java
@@ -3,12 +3,12 @@ package com.telenor.connect.utils;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.squareup.okhttp.OkHttpClient;
+import com.telenor.connect.WellKnownAPI;
 import com.telenor.connect.id.ConnectAPI;
 import com.telenor.connect.id.IdToken;
 import com.telenor.connect.id.IdTokenDeserializer;
 import com.telenor.mobileconnect.id.MobileConnectAPI;
 import com.telenor.mobileconnect.operatordiscovery.OperatorDiscoveryAPI;
-import com.telenor.connect.WellKnownAPI;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,7 +16,6 @@ import java.util.concurrent.TimeUnit;
 
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
-import retrofit.client.Client;
 import retrofit.client.OkClient;
 import retrofit.converter.GsonConverter;
 

--- a/connect/src/com/telenor/connect/utils/Validator.java
+++ b/connect/src/com/telenor/connect/utils/Validator.java
@@ -3,6 +3,7 @@ package com.telenor.connect.utils;
 import com.telenor.connect.ConnectException;
 import com.telenor.connect.ConnectNotInitializedException;
 import com.telenor.connect.ConnectSdk;
+import com.telenor.connect.ConnectSdkProfile;
 import com.telenor.connect.id.ConnectTokensTO;
 
 import java.util.Date;
@@ -23,7 +24,14 @@ public class Validator {
     public static void sdkInitialized() {
         if (!ConnectSdk.isInitialized()) {
             throw new ConnectNotInitializedException("The SDK was not initialized, call " +
-                    "ConnectSdk.sdkInitialize() first");
+                    "ConnectSdk.sdkInitialize() or ConnectSdk.sdkInitializeMobileConnect() first");
+        }
+    }
+
+    public static void connectIdOnly() {
+        if (!(ConnectSdk.getSdkProfile() instanceof ConnectSdkProfile)) {
+            throw new ConnectNotInitializedException("The SDK was either not initialized or not " +
+                    "initialized in the right way; call ConnectSdk.sdkInitialize() first");
         }
     }
 

--- a/connect/src/com/telenor/mobileconnect/operatordiscovery/OperatorDiscoveryAPI.java
+++ b/connect/src/com/telenor/mobileconnect/operatordiscovery/OperatorDiscoveryAPI.java
@@ -10,11 +10,9 @@ import java.net.URL;
 import java.util.List;
 
 import retrofit.Callback;
-import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.Header;
 import retrofit.http.Headers;
-import retrofit.http.POST;
 import retrofit.http.Query;
 
 public interface OperatorDiscoveryAPI {
@@ -27,6 +25,13 @@ public interface OperatorDiscoveryAPI {
             @Query("Identified-MCC") String identifiedMcc,
             @Query("Identified-MNC") String identifiedMnc,
             Callback<OperatorDiscoveryResult> callback);
+
+    @Headers("Content-Type: application/json")
+    @GET("/")
+    void getOperatorSelectionResult(
+            @Header("Authorization") String auth,
+            @Query("Redirect_URL") String redirectUrl,
+            Callback<OperatorSelectionResult> callback);
 
     class OperatorDiscoveryResult {
 
@@ -126,12 +131,31 @@ public interface OperatorDiscoveryAPI {
                 throw new ConnectException(e);
             }
         }
+
         public String getWellKnownEndpoint() {
             String endpoint = getEndpoint("openid-configuration");
             if (endpoint != null) {
                 return endpoint;
             }
             return getBasePath() + WellKnownAPI.OPENID_CONFIGURATION_PATH;
+        }
+    }
+
+    class OperatorSelectionResult {
+
+        @SerializedName("links")
+        private List<OperatorDiscoveryResult.OperatorIdApiEndpoint> links;
+
+        public String getEndpoint() {
+            if (links == null) {
+                return null;
+            }
+            for (OperatorDiscoveryResult.OperatorIdApiEndpoint endpoint : links) {
+                if (endpoint.usage.equals("operatorSelection")) {
+                    return endpoint.href;
+                }
+            }
+            return null;
         }
     }
 }

--- a/connect/tests/src/test/java/com/telenor/connect/id/ConnectIdServiceTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/id/ConnectIdServiceTest.java
@@ -4,13 +4,10 @@ import com.telenor.connect.ConnectNotSignedInException;
 import com.telenor.connect.ConnectRefreshTokenMissingException;
 import com.telenor.connect.utils.Validator;
 
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 

--- a/connect/tests/src/test/java/com/telenor/connect/ui/ConnectLoginButtonTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/ui/ConnectLoginButtonTest.java
@@ -22,8 +22,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
-import static com.telenor.TestHelper.MOCKED_VALID_WELL_KNOWN_API;
 import static com.telenor.TestHelper.DUMMY_ISSUER;
+import static com.telenor.TestHelper.MOCKED_VALID_WELL_KNOWN_API;
 import static com.telenor.TestHelper.WELL_KNOWN_API_MAP;
 import static com.telenor.TestHelper.flushForegroundTasksUntilCallerIsSatisifed;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/connect/tests/src/test/java/com/telenor/connect/ui/ConnectWebViewClientTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/ui/ConnectWebViewClientTest.java
@@ -8,9 +8,10 @@ import android.webkit.WebView;
 
 import com.telenor.connect.ConnectCallback;
 import com.telenor.connect.ConnectSdk;
+import com.telenor.connect.SdkProfile;
+import com.telenor.connect.id.ParseTokenCallback;
 import com.telenor.connect.sms.SmsBroadcastReceiver;
 import com.telenor.connect.utils.ConnectUtils;
-import com.telenor.connect.id.ParseTokenCallback;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +35,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
@@ -215,8 +217,11 @@ public class ConnectWebViewClientTest {
 
     @Test
     public void urlsThatStartWithRedirectUriCallsParseAuthCode() {
+        SdkProfile sdkProfileMock = mock(SdkProfile.class);
+        when(sdkProfileMock.isInitialized()).thenReturn(true);
+
         mockStatic(ConnectSdk.class);
-        given(ConnectSdk.isInitialized()).willReturn(true);
+        given(ConnectSdk.getSdkProfile()).willReturn(sdkProfileMock);
         given(ConnectSdk.getRedirectUri()).willReturn("redirect-uri");
 
         mockStatic(ConnectUtils.class);

--- a/connect/tests/src/test/java/com/telenor/connect/utils/IdTokenValidatorTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/utils/IdTokenValidatorTest.java
@@ -20,15 +20,12 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Matchers.anyList;
-import static org.mockito.Matchers.anyString;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(ConnectSdk.class)

--- a/connect/tests/src/test/java/com/telenor/mobileconnect/MobileConnectTestHelper.java
+++ b/connect/tests/src/test/java/com/telenor/mobileconnect/MobileConnectTestHelper.java
@@ -22,6 +22,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static com.telenor.mobileconnect.operatordiscovery.OperatorDiscoveryAPI.OperatorSelectionResult;
 
 public class MobileConnectTestHelper {
 
@@ -35,6 +36,8 @@ public class MobileConnectTestHelper {
             getFailingOperatorDiscoveryApiMock();
     public static final OperatorDiscoveryAPI MOCKED_VALID_OPERATOR_DISCOVERY_API =
             getValidOperatorDiscoveryApiMock();
+    public static final OperatorDiscoveryAPI MOCKED_VALID_OPERATOR_SELECTION_API =
+            getValidOperatorSelectionApiMock();
 
     private static final String MOCKED_API_URL = "https://dummy/operator/oauth";
     private static final String MOCKED_CLIENT_ID = "dummy-client";
@@ -58,9 +61,29 @@ public class MobileConnectTestHelper {
         return api;
     }
 
+    private static OperatorDiscoveryAPI getValidOperatorSelectionApiMock() {
+        final OperatorSelectionResult osResult =
+                mock(OperatorSelectionResult.class);
+        when(osResult.getEndpoint()).thenReturn(MOCKED_MOBILE_REDIRECT_URI);
+        OperatorDiscoveryAPI api = getFailingOperatorDiscoveryApiMock();
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Callback<OperatorSelectionResult> callback =
+                        (Callback<OperatorSelectionResult>) invocation.getArguments()[2];
+                callback.success(osResult, null);
+                return null;
+            }
+        }).when(api).getOperatorSelectionResult(
+                anyString(),
+                anyString(),
+                any(Callback.class));
+        return api;
+    }
+
     private static OperatorDiscoveryAPI getValidOperatorDiscoveryApiMock() {
-        final OperatorDiscoveryAPI.OperatorDiscoveryResult odResult =
-                mock(OperatorDiscoveryAPI.OperatorDiscoveryResult.class);
+        final OperatorDiscoveryResult odResult =
+                mock(OperatorDiscoveryResult.class);
         when(odResult.getWellKnownEndpoint()).thenReturn(MOCKED_WELL_KNOWN_ENDPONT);
         when(odResult.getMobileConnectApiUrl()).thenReturn(HttpUrl.parse(MOCKED_API_URL));
         when(odResult.getClientId()).thenReturn(MOCKED_CLIENT_ID);

--- a/connect/tests/src/test/java/com/telenor/mobileconnect/ui/MobileConnectLoginButtonTest.java
+++ b/connect/tests/src/test/java/com/telenor/mobileconnect/ui/MobileConnectLoginButtonTest.java
@@ -27,9 +27,9 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowContextImpl;
 import org.robolectric.shadows.ShadowTelephonyManager;
 
+import static com.telenor.TestHelper.BooleanSupplier;
 import static com.telenor.TestHelper.MOCKED_FAILING_WELL_KNOWN_API;
 import static com.telenor.TestHelper.MOCKED_VALID_WELL_KNOWN_API;
-import static com.telenor.TestHelper.BooleanSupplier;
 import static com.telenor.TestHelper.MOCKED_WELL_KNOWN_ENDPONT;
 import static com.telenor.TestHelper.WELL_KNOWN_API_MAP;
 import static com.telenor.TestHelper.flushForegroundTasksUntilCallerIsSatisifed;

--- a/connect/tests/src/test/java/com/telenor/mobileconnect/ui/MobileConnectLoginButtonTest.java
+++ b/connect/tests/src/test/java/com/telenor/mobileconnect/ui/MobileConnectLoginButtonTest.java
@@ -24,6 +24,7 @@ import org.powermock.reflect.Whitebox;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowContextImpl;
 import org.robolectric.shadows.ShadowTelephonyManager;
 
@@ -40,6 +41,7 @@ import static com.telenor.mobileconnect.MobileConnectTestHelper.MOCKED_MOBILE_CO
 import static com.telenor.mobileconnect.MobileConnectTestHelper.MOCKED_MOBILE_REDIRECT_URI;
 import static com.telenor.mobileconnect.MobileConnectTestHelper.MOCKED_OD_ENDPONT;
 import static com.telenor.mobileconnect.MobileConnectTestHelper.MOCKED_VALID_OPERATOR_DISCOVERY_API;
+import static com.telenor.mobileconnect.MobileConnectTestHelper.MOCKED_VALID_OPERATOR_SELECTION_API;
 import static com.telenor.mobileconnect.MobileConnectTestHelper.OPERATOR_DISCOVERY_API_MAP;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -128,5 +130,34 @@ public class MobileConnectLoginButtonTest {
         assertThat(startedIntent.getComponent(), is(expected.getComponent()));
         assertThat(startedIntent.getAction(), is(ConnectUtils.LOGIN_ACTION));
         assertThat(ConnectSdk.getWellKnownConfig().getIssuer(), is(TestHelper.DUMMY_ISSUER));
+    }
+
+    @Test
+    public void clickingLoginButtonWithFailingOperatorDiscoveryResultStartsDivertedConnectActivity() {
+        WELL_KNOWN_API_MAP.put(MOCKED_WELL_KNOWN_ENDPONT, MOCKED_VALID_WELL_KNOWN_API);
+        OPERATOR_DISCOVERY_API_MAP.put(MOCKED_OD_ENDPONT, MOCKED_VALID_OPERATOR_SELECTION_API);
+
+        final Activity activity = Robolectric.buildActivity(TestActivity.class).create().get();
+        final ConnectLoginButton button = (ConnectLoginButton) activity.findViewById(R.id.login_button);
+        button.setLoginScopeTokens("profile");
+        button.performClick();
+
+        assertThat("Activity is started",
+                flushForegroundTasksUntilCallerIsSatisifed(
+                        3000,
+                        new BooleanSupplier() {
+                            @Override
+                            public boolean getAsBoolean() {
+                                ShadowActivity.IntentForResult intentForResult =
+                                        shadowOf(activity).peekNextStartedActivityForResult();
+                                if (intentForResult == null) {
+                                    return false;
+                                }
+                                return intentForResult.intent.getBooleanExtra(
+                                        ConnectUtils.IS_DIVERTED_TO_FETCH_INIT_URI,
+                                        false);
+                            }
+                        }
+                ), is(true));
     }
 }


### PR DESCRIPTION
In order to enable Mobile Connect authentication on devices without SIM card, we divert auth flow to operator selection. The actual initialisation is delayed until the interception of the redirect URI.