### PR TITLE
Extend Forced HE to support Bluetooth and USB

### DIFF
--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -489,7 +489,7 @@ public final class ConnectSdk {
     /**
      * Initialize components common to both Mobile Connect and ConnectID SDK profiles
      */
-    public static synchronized void initializeCommonComponents() {
+    private static synchronized void initializeCommonComponents() {
         connectivityManager
                 = (ConnectivityManager) getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
@@ -520,7 +520,7 @@ public final class ConnectSdk {
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public static void initalizeCellularNetwork() {
+    private static void initalizeCellularNetwork() {
         NetworkRequest networkRequest = new NetworkRequest.Builder()
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
                 .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
@@ -537,7 +537,7 @@ public final class ConnectSdk {
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public static void initalizeDefaultNetwork() {
+    private static void initalizeDefaultNetwork() {
         NetworkRequest networkRequest = new NetworkRequest.Builder()
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
                 .build();

--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
+import android.net.NetworkInfo;
 import android.net.NetworkRequest;
 import android.net.Uri;
 import android.os.Build;
@@ -52,7 +53,7 @@ public final class ConnectSdk {
     private static SdkProfile sdkProfile;
     private static ConnectivityManager connectivityManager;
     private static volatile Network cellularNetwork;
-    private static volatile Network wifiNetwork;
+    private static volatile Network defaultNetwork;
 
     /**
      * The key for the client ID in the Android manifest.
@@ -485,16 +486,40 @@ public final class ConnectSdk {
         profile.deInitialize();
     }
 
-    public static ConnectivityManager getConnectivityManager() {
-        return connectivityManager;
+    /**
+     * Initialize components common to both Mobile Connect and ConnectID SDK profiles
+     */
+    public static synchronized void initializeCommonComponents() {
+        connectivityManager
+                = (ConnectivityManager) getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return;
+        }
+        initalizeCellularNetwork();
+        initalizeDefaultNetwork();
     }
 
-    public static Network getCellularNetwork() {
-        return cellularNetwork;
+    public static boolean isCellularDataNetworkConnected() {
+        Validator.sdkInitialized();
+        NetworkInfo networkInfo = null;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE);
+        } else {
+            if (cellularNetwork == null) {
+                return false;
+            }
+            networkInfo = connectivityManager.getNetworkInfo(cellularNetwork);
+        }
+        return (networkInfo != null) && networkInfo.isConnected();
     }
 
-    public static Network getWifiNetwork() {
-        return wifiNetwork;
+    public static boolean isCellularDataNetworkDefault() {
+        Validator.sdkInitialized();
+        NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
+        if (networkInfo != null && networkInfo.getType() == ConnectivityManager.TYPE_MOBILE) {
+            return true;
+        }
+        return false;
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
@@ -515,35 +540,28 @@ public final class ConnectSdk {
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public static void initalizeWiFiNetwork() {
+    public static void initalizeDefaultNetwork() {
         NetworkRequest networkRequest = new NetworkRequest.Builder()
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
                 .build();
         connectivityManager.requestNetwork(
                 networkRequest,
                 new ConnectivityManager.NetworkCallback() {
                     @Override
                     public void onAvailable(Network network) {
-                        wifiNetwork = network;
+                        defaultNetwork = network;
                     }
                 }
         );
     }
 
-    /**
-     * Initialize components common to both Mobile Connect and ConnectID SDK profiles
-     */
-    public static synchronized void initializeCommonComponents() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            return;
-        }
-        connectivityManager
-                = (ConnectivityManager) getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
-        if (null == connectivityManager) {
-            return;
-        }
-        initalizeCellularNetwork();
-        initalizeWiFiNetwork();
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public static Network getCellularNetwork() {
+        return cellularNetwork;
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public static Network getDefaultNetwork() {
+        return defaultNetwork;
     }
 }

--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -516,10 +516,7 @@ public final class ConnectSdk {
     public static boolean isCellularDataNetworkDefault() {
         Validator.sdkInitialized();
         NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
-        if (networkInfo != null && networkInfo.getType() == ConnectivityManager.TYPE_MOBILE) {
-            return true;
-        }
-        return false;
+        return networkInfo != null && networkInfo.getType() == ConnectivityManager.TYPE_MOBILE;
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/connect/src/com/telenor/connect/ui/ConnectWebViewClient.java
+++ b/connect/src/com/telenor/connect/ui/ConnectWebViewClient.java
@@ -112,9 +112,8 @@ public class ConnectWebViewClient extends WebViewClient implements SmsHandler, I
     @Override
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        boolean shouldSkipInterceptionLogic
-                = ConnectSdk.getCellularNetwork() == null || ConnectSdk.getWifiNetwork() == null;
-        if (shouldSkipInterceptionLogic) {
+        if (!ConnectSdk.isCellularDataNetworkConnected()
+                || ConnectSdk.isCellularDataNetworkDefault()) {
             return null;
         }
         if (shouldFetchThroughCellular(request.getUrl().toString())) {
@@ -188,7 +187,7 @@ public class ConnectWebViewClient extends WebViewClient implements SmsHandler, I
             }
             interfaceToUse = shouldFetchThroughCellular(newUrl)
                     ? ConnectSdk.getCellularNetwork()
-                    : ConnectSdk.getWifiNetwork();
+                    : ConnectSdk.getDefaultNetwork();
         } while (attempts <= ConnectSdk.MAX_REDIRECTS_TO_FOLLOW_FOR_HE);
         return null;
     }

--- a/connect/tests/src/test/java/com/telenor/connect/utils/ConnectUrlHelperTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/utils/ConnectUrlHelperTest.java
@@ -16,8 +16,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Locale;

--- a/connect/tests/src/test/java/com/telenor/connect/utils/ConnectUrlHelperTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/utils/ConnectUrlHelperTest.java
@@ -16,6 +16,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Locale;


### PR DESCRIPTION
1. Avoid forcing HE on a disconnected (stale) cellular network
2. Make the patch WiFi-independent, making it possible to force HE over tethered connections other that WiFi (e.g. Bluetooth and USB)