### PR TITLE
Extend Forced HE to support Bluetooth and USB

### DIFF
--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -518,12 +518,9 @@ public final class ConnectSdk {
      * Initialize components common to both Mobile Connect and ConnectID SDK profiles
      */
     private static synchronized void initializeCommonComponents() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            return;
-        }
         connectivityManager
                 = (ConnectivityManager) getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
-        if (connectivityManager == null) {
+        if (connectivityManager == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             return;
         }
         initalizeCellularNetwork();

--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -518,9 +518,12 @@ public final class ConnectSdk {
      * Initialize components common to both Mobile Connect and ConnectID SDK profiles
      */
     private static synchronized void initializeCommonComponents() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return;
+        }
         connectivityManager
                 = (ConnectivityManager) getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        if (connectivityManager == null) {
             return;
         }
         initalizeCellularNetwork();
@@ -528,7 +531,9 @@ public final class ConnectSdk {
     }
 
     public static boolean isCellularDataNetworkConnected() {
-        Validator.sdkInitialized();
+        if (connectivityManager == null) {
+            return false;
+        }
         NetworkInfo networkInfo = null;
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE);
@@ -542,7 +547,9 @@ public final class ConnectSdk {
     }
 
     public static boolean isCellularDataNetworkDefault() {
-        Validator.sdkInitialized();
+        if (connectivityManager == null) {
+            return false;
+        }
         NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
         return networkInfo != null && networkInfo.getType() == ConnectivityManager.TYPE_MOBILE;
     }

--- a/connect/src/com/telenor/connect/ui/ConnectWebViewClient.java
+++ b/connect/src/com/telenor/connect/ui/ConnectWebViewClient.java
@@ -112,9 +112,8 @@ public class ConnectWebViewClient extends WebViewClient implements SmsHandler, I
     @Override
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        boolean shouldSkipInterceptionLogic
-                = ConnectSdk.getCellularNetwork() == null || ConnectSdk.getWifiNetwork() == null;
-        if (shouldSkipInterceptionLogic) {
+        if (!ConnectSdk.isCellularDataNetworkConnected()
+                || ConnectSdk.isCellularDataNetworkDefault()) {
             return null;
         }
         if (shouldFetchThroughCellular(request.getUrl().toString())) {
@@ -188,7 +187,7 @@ public class ConnectWebViewClient extends WebViewClient implements SmsHandler, I
             }
             interfaceToUse = shouldFetchThroughCellular(newUrl)
                     ? ConnectSdk.getCellularNetwork()
-                    : ConnectSdk.getWifiNetwork();
+                    : ConnectSdk.getDefaultNetwork();
         } while (attempts <= ConnectSdk.MAX_REDIRECTS_TO_FOLLOW_FOR_HE);
         return null;
     }


### PR DESCRIPTION
1. Avoid forcing HE on a disconnected (stale) cellular network
2. Make the patch WiFi-independent, making it possible to force HE over the tethered connection other that WiFi (e.g. Bluetooth and USB)