### PR TITLE
Avoid requesting /oauth/revoke without tokens

### DIFF
--- a/connect/src/com/telenor/connect/id/ConnectIdService.java
+++ b/connect/src/com/telenor/connect/id/ConnectIdService.java
@@ -100,32 +100,38 @@ public class ConnectIdService {
     }
 
     public void revokeTokens(Context context) {
-        connectApi.revokeToken(
-                clientId,
-                getAccessToken(),
-                new ResponseCallback() {
-            @Override
-            public void success(Response response) {
-            }
+        String accessToken = getAccessToken();
+        if (accessToken != null) {
+            connectApi.revokeToken(
+                    clientId,
+                    accessToken,
+                    new ResponseCallback() {
+                        @Override
+                        public void success(Response response) {
+                        }
 
-            @Override
-            public void failure(RetrofitError error) {
-                Log.e(ConnectUtils.LOG_TAG, "Failed to call revoke access token on API", error);
-            }
-        });
-        connectApi.revokeToken(
-                clientId,
-                getRefreshToken(),
-                new ResponseCallback() {
-            @Override
-            public void success(Response response) {
-            }
+                        @Override
+                        public void failure(RetrofitError error) {
+                            Log.e(ConnectUtils.LOG_TAG, "Failed to call revoke access token on API", error);
+                        }
+                    });
+        }
+        String refreshToken = getRefreshToken();
+        if (refreshToken != null) {
+            connectApi.revokeToken(
+                    clientId,
+                    refreshToken,
+                    new ResponseCallback() {
+                        @Override
+                        public void success(Response response) {
+                        }
 
-            @Override
-            public void failure(RetrofitError error) {
-                Log.e(ConnectUtils.LOG_TAG, "Failed to call revoke refresh token on API", error);
-            }
-        });
+                        @Override
+                        public void failure(RetrofitError error) {
+                            Log.e(ConnectUtils.LOG_TAG, "Failed to call revoke refresh token on API", error);
+                        }
+                    });
+        }
         tokenStore.clear();
         currentTokens = null;
         idToken = null;

--- a/connect/src/com/telenor/connect/id/ConnectIdService.java
+++ b/connect/src/com/telenor/connect/id/ConnectIdService.java
@@ -2,6 +2,7 @@ package com.telenor.connect.id;
 
 import android.content.Context;
 import android.os.Build;
+import android.text.TextUtils;
 import android.util.Log;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
@@ -101,7 +102,7 @@ public class ConnectIdService {
 
     public void revokeTokens(Context context) {
         String accessToken = getAccessToken();
-        if (accessToken != null) {
+        if (!TextUtils.isEmpty(accessToken)) {
             connectApi.revokeToken(
                     clientId,
                     accessToken,
@@ -117,7 +118,7 @@ public class ConnectIdService {
                     });
         }
         String refreshToken = getRefreshToken();
-        if (refreshToken != null) {
+        if (!TextUtils.isEmpty(refreshToken)) {
             connectApi.revokeToken(
                     clientId,
                     refreshToken,


### PR DESCRIPTION
A possible pattern could be that they call ConnectSdk.logout() without previously
being logged in, possibly to make a fresh start or something. It is worth mentioning
that this pattern does not produce a crash in the app, just some annoying log entries
in it (and on the backend side as well).

Though this pattern looks like a misuse of the SDK, I think the SDK (and the backend
for that matter)  would benefit from not calling the revoke endpoint without tokens.
Otherwise, we might be snowed down with http 400 if many apps call
ConnectSdk.logout() unconditionally.