### PR TITLE
Introduce session not-null check in ConnectLoginButton

### DIFF
--- a/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 import android.support.customtabs.CustomTabsClient;
 import android.support.customtabs.CustomTabsIntent;
 import android.support.customtabs.CustomTabsServiceConnection;
+import android.support.customtabs.CustomTabsSession;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
@@ -54,9 +55,10 @@ public class ConnectLoginButton extends ConnectWebViewLoginButton {
             @Override
             public void onCustomTabsServiceConnected(ComponentName name, CustomTabsClient client) {
                 client.warmup(0);
-                client
-                        .newSession(null)
-                        .mayLaunchUrl(PRE_FETCH_URL, null, null);
+                CustomTabsSession session = client.newSession(null);
+                if (session != null) {
+                    session.mayLaunchUrl(PRE_FETCH_URL, null, null);
+                }
             }
 
             @Override


### PR DESCRIPTION
I haven't managed to recreate this error on my device, but we may have reasons
to merge this patch anyway.

My suspicion is, since client.warmup() is async, the client may not be always able
to create a new session if, for example, still "cold". I am not sure if this is exactly
the case here, but this patch can be safely merged even without being 100% sure.

The documentation states that client.newSession() may return null in case of errors
without being specific what kind of errors they might be. For that reason, it's sound
to check the session's validity prior to invoking its methods in any case.

If the not-null check introduced here fails for some reason, the only consequence would
be that we would have an Url that is not pre-optimized PRE_FETCH_URL. This would lead to
a performance that is somwhat slower, but way better than NullPointerException.