### PR TITLE
Fix ClassCastException crash

### DIFF
--- a/connect/src/com/telenor/connect/id/ConnectIdService.java
+++ b/connect/src/com/telenor/connect/id/ConnectIdService.java
@@ -14,6 +14,8 @@ import com.telenor.connect.utils.ConnectUtils;
 import com.telenor.connect.utils.HeadersDateUtil;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import retrofit.Callback;
 import retrofit.ResponseCallback;
@@ -99,7 +101,9 @@ public class ConnectIdService {
                     public void failure(RetrofitError error) {
                         ConnectUtils.sendTokenStateChanged(false);
                         if (callback != null) {
-                            callback.onError(error.toString());
+                            Map<String, String> errorParams = new HashMap<>();
+                            errorParams.put("error", error.toString());
+                            callback.onError(errorParams);
                         }
                     }
                 });


### PR DESCRIPTION
Fix the crash with crash dump:
Fatal Exception: java.lang.ClassCastException: java.lang.String cannot
be cast to java.util.Map
       at
com.telenor.connect.ui.ConnectActivity.onError(ConnectActivity.java:100)
       at
com.telenor.connect.id.ConnectIdService$1.failure(ConnectIdService.java:89)
       at retrofit.CallbackRunnable$2.run(CallbackRunnable.java:53)
       at android.os.Handler.handleCallback(Handler.java:808)
       at android.os.Handler.dispatchMessage(Handler.java:103)
       at android.os.Looper.loop(Looper.java:193)
       at android.app.ActivityThread.main(ActivityThread.java:5398)
       at java.lang.reflect.Method.invokeNative(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:515)
       at
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:940)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:756)
       at dalvik.system.NativeStart.main(NativeStart.java)