### PR TITLE
Scrap lastAuthState vairable

### DIFF
--- a/connect/src/com/telenor/connect/AbstractSdkProfile.java
+++ b/connect/src/com/telenor/connect/AbstractSdkProfile.java
@@ -26,8 +26,6 @@ public abstract class AbstractSdkProfile implements SdkProfile {
     private volatile boolean isInitialized = false;
     private final WellKnownConfigStore lastSeenStore;
 
-    private String lastAuthState;
-
     public AbstractSdkProfile(
             Context context,
             boolean confidentialClient) {
@@ -89,7 +87,6 @@ public abstract class AbstractSdkProfile implements SdkProfile {
         if (TextUtils.isEmpty(parameters.get("state"))) {
             parameters.put("state", UUID.randomUUID().toString());
         }
-        lastAuthState = parameters.get("state");
     }
 
     protected void initializeAndContinueAuthorizationFlow(final OnStartAuthorizationCallback callback) {
@@ -114,11 +111,6 @@ public abstract class AbstractSdkProfile implements SdkProfile {
                         callback.onSuccess();
                     }
                 });
-    }
-
-    @Override
-    public String getLastAuthState() {
-        return lastAuthState;
     }
 
     @Override

--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -264,11 +264,6 @@ public final class ConnectSdk {
         return sdkProfile.getClientId();
     }
 
-    public static String getLastAuthenticationState() {
-        Validator.sdkInitialized();
-        return getSdkProfile().getLastAuthState();
-    }
-
     public static ArrayList<Locale> getLocales() {
         Validator.sdkInitialized();
         return sLocales;

--- a/connect/src/com/telenor/connect/SdkProfile.java
+++ b/connect/src/com/telenor/connect/SdkProfile.java
@@ -26,8 +26,6 @@ public interface SdkProfile {
     WellKnownAPI.WellKnownConfig getWellKnownConfig();
     boolean isInitialized();
 
-    String getLastAuthState();
-
     void onStartAuthorization(Map<String, String> parameters, OnStartAuthorizationCallback callback);
 
     interface OnStartAuthorizationCallback {

--- a/connect/src/com/telenor/connect/ui/ConnectWebViewClient.java
+++ b/connect/src/com/telenor/connect/ui/ConnectWebViewClient.java
@@ -28,7 +28,6 @@ import com.telenor.connect.utils.ConnectUtils;
 import com.telenor.connect.utils.JavascriptUtil;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
@@ -91,7 +90,7 @@ public class ConnectWebViewClient extends WebViewClient implements SmsHandler, I
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
         if (ConnectSdk.getRedirectUri() != null
                 && url.startsWith(ConnectSdk.getRedirectUri())) {
-            ConnectUtils.parseAuthCode(url, connectCallback);
+            ConnectUtils.parseAuthCode(url, getOriginalState(), connectCallback);
             return true;
         }
         if (ConnectSdk.getPaymentCancelUri() != null
@@ -107,6 +106,11 @@ public class ConnectWebViewClient extends WebViewClient implements SmsHandler, I
             return true;
         }
         return false;
+    }
+
+    private String getOriginalState() {
+        String url = activity.getIntent().getStringExtra(ConnectUtils.LOGIN_AUTH_URI);
+        return Uri.parse(url).getQueryParameter("state");
     }
 
     @Override

--- a/connect/src/com/telenor/connect/utils/ConnectUtils.java
+++ b/connect/src/com/telenor/connect/utils/ConnectUtils.java
@@ -21,11 +21,13 @@ public class ConnectUtils {
     public static final String WELL_KNOWN_CONFIG_EXTRA = "com.telenor.connect.WELL_KNOWN_CONFIG";
     public static final String ACR_VALUES_PARAM_NAME = "acr_values";
 
-    public static void parseAuthCode(String callbackUrl, ConnectCallback callback) {
+    public static void parseAuthCode(String callbackUrl,
+                                     String originalState,
+                                     ConnectCallback callback) {
         Validator.notNullOrEmpty(callbackUrl, "callbackUrl");
 
         Uri uri = Uri.parse(callbackUrl);
-        if (!Validator.validState(uri.getQueryParameter("state"))) {
+        if (!originalState.equals(uri.getQueryParameter("state"))) {
             Map<String, String> errorParams = new HashMap<>();
             errorParams.put("error", "state_changed");
             errorParams.put(

--- a/connect/src/com/telenor/connect/utils/Validator.java
+++ b/connect/src/com/telenor/connect/utils/Validator.java
@@ -33,19 +33,6 @@ public class Validator {
         }
     }
 
-    public static void validateAuthenticationState(String state) {
-        if (!validState(state)) {
-            throw new ConnectException("The state parameter was changed between authentication " +
-                    "and now.");
-        }
-    }
-
-    public static boolean validState(String state) {
-        return ConnectSdk.getLastAuthenticationState() == null
-                || ConnectSdk.getLastAuthenticationState().isEmpty()
-                || ConnectSdk.getLastAuthenticationState().equals(state);
-    }
-
     public static void validateTokens(ConnectTokensTO tokens, Date serverTimestamp) {
         sdkInitialized();
         ConnectSdk.getSdkProfile().validateTokens(tokens, serverTimestamp);

--- a/connect/tests/src/test/java/com/telenor/connect/ui/ConnectWebViewClientTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/ui/ConnectWebViewClientTest.java
@@ -1,6 +1,7 @@
 package com.telenor.connect.ui;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.content.IntentFilter;
 import android.support.annotation.NonNull;
 import android.view.View;
@@ -29,11 +30,13 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
@@ -221,10 +224,13 @@ public class ConnectWebViewClientTest {
 
         mockStatic(ConnectUtils.class);
         doNothing().when(ConnectUtils.class);
-        ConnectUtils.parseAuthCode(eq("redirect-uri"), any(ParseTokenCallback.class));
+        ConnectUtils.parseAuthCode(eq("redirect-uri"), anyString(), any(ParseTokenCallback.class));
 
         ConnectCallback callback = mock(ConnectCallback.class);
         Activity activity = mock(Activity.class);
+        Intent intent = mock(Intent.class);
+        when(intent.getStringExtra(ConnectUtils.LOGIN_AUTH_URI)).thenReturn("redirect-uri");
+        when(activity.getIntent()).thenReturn(intent);
         WebView webView = mock(WebView.class);
         View loadingView = mock(View.class);
         View errorView = mock(View.class);
@@ -238,6 +244,6 @@ public class ConnectWebViewClientTest {
 
         assertThat(result, is(true));
         verifyStatic();
-        ConnectUtils.parseAuthCode(eq("redirect-uri"), any(ParseTokenCallback.class));
+        ConnectUtils.parseAuthCode(eq("redirect-uri"), anyString(), any(ParseTokenCallback.class));
     }
 }

--- a/connect/tests/src/test/java/com/telenor/connect/utils/ConnectUtilsTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/utils/ConnectUtilsTest.java
@@ -40,9 +40,11 @@ public class ConnectUtilsTest {
         mockStatic(ConnectSdk.class);
         BDDMockito.given(ConnectSdk.isInitialized()).willReturn(true);
 
+        String state = "somestate";
         final String value1 = "something";
         final String value2 = "something else";
         String uri = new Uri.Builder()
+                .appendQueryParameter("state", state)
                 .appendQueryParameter("error", value1)
                 .appendQueryParameter("error_description", value2)
                 .build()
@@ -50,7 +52,7 @@ public class ConnectUtilsTest {
 
         ConnectCallback mock = mock(ConnectCallback.class);
 
-        ConnectUtils.parseAuthCode(uri, mock);
+        ConnectUtils.parseAuthCode(uri, state, mock);
         verify(mock).onError(argThat(new ArgumentMatcher<Object>() {
             @Override
             public boolean matches(Object argument) {
@@ -76,7 +78,7 @@ public class ConnectUtilsTest {
 
         ConnectCallback mock = mock(ConnectCallback.class);
 
-        ConnectUtils.parseAuthCode(uri, mock);
+        ConnectUtils.parseAuthCode(uri, value2, mock);
         verify(mock).onSuccess(argThat(new ArgumentMatcher<Object>() {
             @Override
             public boolean matches(Object argument) {

--- a/connect/tests/src/test/java/com/telenor/connect/utils/ConnectUtilsTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/utils/ConnectUtilsTest.java
@@ -64,6 +64,29 @@ public class ConnectUtilsTest {
     }
 
     @Test
+    public void mutatedStateInCallbackUrlCallsCallbackOnErrorWithMap() {
+        mockStatic(ConnectSdk.class);
+        BDDMockito.given(ConnectSdk.isInitialized()).willReturn(true);
+
+        String state = "somestate";
+        String uri = new Uri.Builder()
+                .appendQueryParameter("state", state + "mutation")
+                .build()
+                .toString();
+
+        ConnectCallback mock = mock(ConnectCallback.class);
+
+        ConnectUtils.parseAuthCode(uri, state, mock);
+        verify(mock).onError(argThat(new ArgumentMatcher<Object>() {
+            @Override
+            public boolean matches(Object argument) {
+                Map<String, String> stringMap = (Map<String, String>) argument;
+                return stringMap.get("error").equals("state_changed");
+            }
+        }));
+    }
+
+    @Test
     public void successfulCallbackUrlCallsCallbackOnSuccessWithMap() {
         mockStatic(ConnectSdk.class);
         BDDMockito.given(ConnectSdk.isInitialized()).willReturn(true);

--- a/connect/tests/src/test/java/com/telenor/connect/utils/ValidatorTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/utils/ValidatorTest.java
@@ -19,8 +19,6 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -74,19 +72,6 @@ public class ValidatorTest {
         BDDMockito.given(ConnectSdk.isInitialized()).willReturn(true);
 
         Validator.sdkInitialized();
-    }
-
-    @Test(expected = ConnectException.class)
-    public void validateAuthenticationStateThrowsOnUnEqualState() {
-        BDDMockito.given(ConnectSdk.getLastAuthenticationState()).willReturn("some state");
-
-        Validator.validateAuthenticationState("not same state");
-    }
-
-    public void validateAuthenticationStateDoesNotThrowOnEqualState() {
-        BDDMockito.given(ConnectSdk.getLastAuthenticationState()).willReturn("some state");
-
-        Validator.validateAuthenticationState("some state");
     }
 
     @Test
@@ -174,33 +159,5 @@ public class ValidatorTest {
                 null);
 
         Validator.validateTokens(connectTokensTO, null);
-    }
-
-    @Test
-    public void validStateReturnsTrueWhenCurrentStateIsNull() {
-        BDDMockito.given(ConnectSdk.getLastAuthenticationState()).willReturn(null);
-
-        assertThat(Validator.validState("whatever"), is(true));
-    }
-
-    @Test
-    public void validStateReturnsTrueWhenCurrentStateIsEmpty() {
-        BDDMockito.given(ConnectSdk.getLastAuthenticationState()).willReturn("");
-
-        assertThat(Validator.validState("whatever"), is(true));
-    }
-
-    @Test
-    public void validStateReturnsTrueWhenCurrentStateMatchesGivenState() {
-        BDDMockito.given(ConnectSdk.getLastAuthenticationState()).willReturn("abc");
-
-        assertThat(Validator.validState("abc"), is(true));
-    }
-
-    @Test
-    public void validStateReturnsFalseWhenCurrentStateDoesNotMatchGivenState() {
-        BDDMockito.given(ConnectSdk.getLastAuthenticationState()).willReturn("xyz");
-
-        assertThat(Validator.validState("abc"), is(false));
     }
 }


### PR DESCRIPTION
We don't need it, since it is already contained within the Uri the ConnectActivity
has been started with. Besides, not having this variable will remove the problems
we might have if developers contrive to call ConnectSdk.authorize() multiple times.
Some of the crash reports indicate that they are doing exactly that.