### PR TITLE
Improve failure handling of CHANGE_NETWORK_STATE acquiring in Android…

### DIFF
--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -622,15 +622,19 @@ public final class ConnectSdk {
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
                 .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
                 .build();
-        connectivityManager.requestNetwork(
-                networkRequest,
-                new ConnectivityManager.NetworkCallback() {
-                    @Override
-                    public void onAvailable(Network network) {
-                        cellularNetwork = network;
+        try {
+            connectivityManager.requestNetwork(
+                    networkRequest,
+                    new ConnectivityManager.NetworkCallback() {
+                        @Override
+                        public void onAvailable(Network network) {
+                            cellularNetwork = network;
+                        }
                     }
-                }
-        );
+            );
+        } catch (SecurityException e) {
+            cellularNetwork = null;
+        }
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
@@ -638,15 +642,19 @@ public final class ConnectSdk {
         NetworkRequest networkRequest = new NetworkRequest.Builder()
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
                 .build();
-        connectivityManager.requestNetwork(
-                networkRequest,
-                new ConnectivityManager.NetworkCallback() {
-                    @Override
-                    public void onAvailable(Network network) {
-                        defaultNetwork = network;
+        try {
+            connectivityManager.requestNetwork(
+                    networkRequest,
+                    new ConnectivityManager.NetworkCallback() {
+                        @Override
+                        public void onAvailable(Network network) {
+                            defaultNetwork = network;
+                        }
                     }
-                }
-        );
+            );
+        } catch (SecurityException e) {
+            defaultNetwork = null;
+        }
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)


### PR DESCRIPTION
… 6.0

Android 6.0 has problems with auto-granting CHANGE_NETWORK_STATE
permission that is required for Forced HE and additional logic is
required to acquire it. This has been fixed in Android 6.0.1.
In case of an exception during requestNetwork() (CHANGE_NETWORK_STATE
was not granted) we should not crash, but just disable Forced HE.