### PR TITLE
Redirect target requirement change

### DIFF
--- a/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
@@ -140,7 +140,7 @@ public class ConnectLoginButton extends ConnectWebViewLoginButton {
         if (componentName == null) {
             return false;
         }
-        return context.getClass().getName().equals(componentName.getClassName());
+        return context.getPackageName().equals(componentName.getPackageName());
     }
 
     @Override


### PR DESCRIPTION
Making the redirect target requirement more lenient by only comparing package names instead of comparing the full class names.
See issue #89.