### PR TITLE
Adding a setter for the custom tab in same/new task behavior

### DIFF
--- a/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
@@ -49,6 +49,7 @@ public class ConnectLoginButton extends ConnectWebViewLoginButton {
     private OnClickListener onClickListener;
     private CustomTabsServiceConnection connection;
     private boolean customTabsSupported = false;
+    private boolean launchCustomTabInNewTask = true;
     private BrowserType browserType;
     private ConnectStore connectStore;
     private CustomTabsSession session;
@@ -93,6 +94,10 @@ public class ConnectLoginButton extends ConnectWebViewLoginButton {
         browserType = customTabsSupported ? BrowserType.CHROME_CUSTOM_TAB : BrowserType.WEB_VIEW;
         onClickListener = new LoginClickListener();
         setOnClickListener(onClickListener);
+    }
+
+    public void setLaunchCustomTabInNewTask(boolean launchCustomTabInNewTask) {
+        this.launchCustomTabInNewTask = launchCustomTabInNewTask;
     }
 
     public OnClickListener getOnClickListener() {
@@ -166,7 +171,9 @@ public class ConnectLoginButton extends ConnectWebViewLoginButton {
         CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(session);
         CustomTabsIntent cctIntent = builder.build();
         Intent intent = cctIntent.intent;
-        intent.setFlags(FLAG_ACTIVITY_NEW_TASK);
+        if (launchCustomTabInNewTask) {
+            intent.setFlags(FLAG_ACTIVITY_NEW_TASK);
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
             intent.putExtra(Intent.EXTRA_REFERRER,
                     Uri.parse(Intent.URI_ANDROID_APP_SCHEME + "//" + getContext().getPackageName()));


### PR DESCRIPTION
A setter lets you launch the custom tabs in the current Task instead of in a new Task. The custom tabs still launch in a new Task by default. See issue #91.