### PR TITLE
Fix ConnectLoginButton context leak

### DIFF
--- a/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
@@ -60,7 +60,7 @@ public class ConnectLoginButton extends ConnectWebViewLoginButton {
         super(context, attributeSet);
         connectStore = new ConnectStore(getContext());
         setText(R.string.com_telenor_connect_login_button_text);
-        connection = new MyCustomTabsServiceConnection(new WeakReference<>(this));
+        connection = new WeakReferenceCustomTabsServiceConnection(new WeakReference<>(this));
         onClickListener = new LoginClickListener();
         setOnClickListener(onClickListener);
     }
@@ -187,11 +187,11 @@ public class ConnectLoginButton extends ConnectWebViewLoginButton {
 
     }
 
-    private static class MyCustomTabsServiceConnection extends CustomTabsServiceConnection {
+    private static class WeakReferenceCustomTabsServiceConnection extends CustomTabsServiceConnection {
 
         private final WeakReference<ConnectLoginButton> weakButton;
 
-        MyCustomTabsServiceConnection(WeakReference<ConnectLoginButton> weakButton) {
+        WeakReferenceCustomTabsServiceConnection(WeakReference<ConnectLoginButton> weakButton) {
             this.weakButton = weakButton;
         }
 
@@ -202,7 +202,7 @@ public class ConnectLoginButton extends ConnectWebViewLoginButton {
                 return;
             }
             client.warmup(0);
-            final CustomTabsSession session = client.newSession(new MyCustomTabsCallback(weakButton));
+            final CustomTabsSession session = client.newSession(new WeakReferenceCustomTabsCallback(weakButton));
             connectLoginButton.setSession(session);
             if (session != null) {
                 session.mayLaunchUrl(PRE_FETCH_URL, null, null);
@@ -214,11 +214,11 @@ public class ConnectLoginButton extends ConnectWebViewLoginButton {
         }
     }
 
-    private static class MyCustomTabsCallback extends CustomTabsCallback {
+    private static class WeakReferenceCustomTabsCallback extends CustomTabsCallback {
 
         private final WeakReference<ConnectLoginButton> weakButton;
 
-        MyCustomTabsCallback(WeakReference<ConnectLoginButton> weakButton) {
+        WeakReferenceCustomTabsCallback(WeakReference<ConnectLoginButton> weakButton) {
             this.weakButton = weakButton;
         }
 

--- a/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
@@ -18,7 +18,6 @@ import android.util.AttributeSet;
 import android.view.View;
 
 import com.telenor.connect.BrowserType;
-import com.telenor.connect.ConnectCallback;
 import com.telenor.connect.ConnectException;
 import com.telenor.connect.ConnectSdk;
 import com.telenor.connect.R;
@@ -29,6 +28,7 @@ import com.telenor.connect.utils.Validator;
 
 import org.json.JSONException;
 
+import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -60,35 +60,7 @@ public class ConnectLoginButton extends ConnectWebViewLoginButton {
         super(context, attributeSet);
         connectStore = new ConnectStore(getContext());
         setText(R.string.com_telenor_connect_login_button_text);
-
-        connection = new CustomTabsServiceConnection() {
-            @Override
-            public void onCustomTabsServiceConnected(ComponentName name, CustomTabsClient client) {
-                client.warmup(0);
-                session = client.newSession(new CustomTabsCallback() {
-                    @Override
-                    public void onNavigationEvent(int navigationEvent, Bundle extras) {
-                        switch (navigationEvent) {
-                            case CustomTabsCallback.TAB_HIDDEN:
-                                ConnectLoginButton.this.setEnabled(true);
-                                return;
-                            case CustomTabsCallback.TAB_SHOWN:
-                                ConnectLoginButton.this.setEnabled(false);
-                                return;
-                            default:
-                        }
-                    }
-                });
-                if (session != null) {
-                    session.mayLaunchUrl(PRE_FETCH_URL, null, null);
-                }
-            }
-
-            @Override
-            public void onServiceDisconnected(ComponentName name) {
-            }
-        };
-
+        connection = new MyCustomTabsServiceConnection(new WeakReference<>(this));
         onClickListener = new LoginClickListener();
         setOnClickListener(onClickListener);
     }
@@ -194,6 +166,10 @@ public class ConnectLoginButton extends ConnectWebViewLoginButton {
         cctIntent.launchUrl(getActivity(), authorizeUri);
     }
 
+    private void setSession(CustomTabsSession session) {
+        this.session = session;
+    }
+
     private class LoginClickListener implements OnClickListener {
 
         @Override
@@ -209,5 +185,58 @@ public class ConnectLoginButton extends ConnectWebViewLoginButton {
             }
         }
 
+    }
+
+    private static class MyCustomTabsServiceConnection extends CustomTabsServiceConnection {
+
+        private final WeakReference<ConnectLoginButton> weakButton;
+
+        MyCustomTabsServiceConnection(WeakReference<ConnectLoginButton> weakButton) {
+            this.weakButton = weakButton;
+        }
+
+        @Override
+        public void onCustomTabsServiceConnected(ComponentName name, CustomTabsClient client) {
+            final ConnectLoginButton connectLoginButton = weakButton.get();
+            if (connectLoginButton == null) {
+                return;
+            }
+            client.warmup(0);
+            final CustomTabsSession session = client.newSession(new MyCustomTabsCallback(weakButton));
+            connectLoginButton.setSession(session);
+            if (session != null) {
+                session.mayLaunchUrl(PRE_FETCH_URL, null, null);
+            }
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName name) {
+        }
+    }
+
+    private static class MyCustomTabsCallback extends CustomTabsCallback {
+
+        private final WeakReference<ConnectLoginButton> weakButton;
+
+        MyCustomTabsCallback(WeakReference<ConnectLoginButton> weakButton) {
+            this.weakButton = weakButton;
+        }
+
+        @Override
+        public void onNavigationEvent(int navigationEvent, Bundle extras) {
+            final ConnectLoginButton connectLoginButton = weakButton.get();
+            if (connectLoginButton == null) {
+                return;
+            }
+            switch (navigationEvent) {
+                case CustomTabsCallback.TAB_HIDDEN:
+                    connectLoginButton.setEnabled(true);
+                    return;
+                case CustomTabsCallback.TAB_SHOWN:
+                    connectLoginButton.setEnabled(false);
+                    return;
+                default:
+            }
+        }
     }
 }


### PR DESCRIPTION
LeakCanary reports a leak every time we use the ConnectLoginButton in our app:

> In se.telenor.mytelenor.alphatest:1.5.6.135.1:135.
> * com.telenor.app.mytelenor.ui.NewLoginActivity has leaked:
> * GC ROOT android.support.customtabs.CustomTabsClient$2.this$0 (anonymous subclass of android.support.customtabs.ICustomTabsCallback$Stub)
> * references android.support.customtabs.CustomTabsServiceConnection$1.this$0 (anonymous subclass of android.support.customtabs.CustomTabsClient)
> * references com.telenor.connect.ui.ConnectLoginButton$1.this$0 (anonymous subclass of android.support.customtabs.CustomTabsServiceConnection)
> * references com.telenor.connect.ui.ConnectLoginButton.mContext
> * leaks com.telenor.app.mytelenor.ui.NewLoginActivity instance

It looks like the anonymous subclass of CustomTabsServiceConnection leaks a reference to the Activity context. Changing to a private static class with a weak reference to the button fixes the problem for us. I've not been able to reproduce the issue with your example app but it would be great if you would consider this change anyway.
