### PR TITLE
Set useStaging in sdkInitialize

### DIFF
--- a/connect-id-example/src/main/AndroidManifest.xml
+++ b/connect-id-example/src/main/AndroidManifest.xml
@@ -39,9 +39,6 @@
         <meta-data
             android:name="com.telenor.connect.REDIRECT_URI"
             android:value="@string/connect_redirect_uri" />
-        <meta-data
-            android:name="com.telenor.connect.USE_STAGING"
-            android:value="true" />
     </application>
 
 </manifest>

--- a/connect-id-example/src/main/java/com/telenor/connect/connectidexample/ExampleApplication.java
+++ b/connect-id-example/src/main/java/com/telenor/connect/connectidexample/ExampleApplication.java
@@ -8,6 +8,6 @@ public class ExampleApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        ConnectSdk.sdkInitialize(getApplicationContext(), true);
+        ConnectSdk.sdkInitialize(getApplicationContext());
     }
 }

--- a/connect-id-example/src/main/java/com/telenor/connect/connectidexample/ExampleApplication.java
+++ b/connect-id-example/src/main/java/com/telenor/connect/connectidexample/ExampleApplication.java
@@ -8,6 +8,6 @@ public class ExampleApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        ConnectSdk.sdkInitialize(getApplicationContext());
+        ConnectSdk.sdkInitialize(getApplicationContext(), true);
     }
 }

--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -321,7 +321,7 @@ public final class ConnectSdk {
     }
 
     public static synchronized void sdkInitialize(Context applicationContext) {
-        sdkInitialize(applicationContext, false);
+        sdkInitialize(applicationContext, true);
     }
 
     public static synchronized void sdkInitialize(Context applicationContext,

--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -89,11 +89,6 @@ public final class ConnectSdk {
      */
     public static final String REDIRECT_URI_PROPERTY = "com.telenor.connect.REDIRECT_URI";
 
-    /**
-     * The key to enable the staging environment in the Android manifest.
-     */
-    public static final String USE_STAGING_PROPERTY = "com.telenor.connect.USE_STAGING";
-
     public static final String ACTION_LOGIN_STATE_CHANGED =
             "com.telenor.connect.ACTION_LOGIN_STATE_CHANGED";
 
@@ -326,12 +321,18 @@ public final class ConnectSdk {
     }
 
     public static synchronized void sdkInitialize(Context applicationContext) {
+        sdkInitialize(applicationContext, false);
+    }
+
+    public static synchronized void sdkInitialize(Context applicationContext,
+                                                  boolean useStagingEnvironment) {
         if (isInitialized()) {
             return;
         }
         context = applicationContext;
         Validator.notNull(context, "context");
 
+        useStaging = useStagingEnvironment;
         loadConnectConfig(context);
         connectStore = new ConnectStore(context);
         lastSeenWellKnownConfigStore = new WellKnownConfigStore(context);
@@ -397,7 +398,6 @@ public final class ConnectSdk {
         if (ai == null || ai.metaData == null) {
             throw new ConnectException("No application metadata was found.");
         }
-        useStaging = fetchBooleanProperty(ai, USE_STAGING_PROPERTY);
         confidentialClient = fetchBooleanProperty(ai, CONFIDENTIAL_CLIENT_PROPERTY);
 
         Object clientIdObject = ai.metaData.get(CLIENT_ID_PROPERTY);

--- a/connect/tests/src/test/java/com/telenor/connect/ConnectSdkTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/ConnectSdkTest.java
@@ -31,12 +31,6 @@ public class ConnectSdkTest {
     }
 
     @Test
-    public void getConnectApiUrlReturnsProductionByDefault() {
-        assertThat(ConnectUrlHelper.getConnectApiUrl().toString(),
-                is("https://connect.telenordigital.com/"));
-    }
-
-    @Test
     public void getsClientIdFromApplicationInfoMetaData() {
         assertThat(ConnectSdk.getClientId(), is("connect-tests"));
     }


### PR DESCRIPTION
The `useStaging` boolean is read from the manifest and cannot be changed during runtime. This is a problem for us because we have to build two versions of our app when we do internal testing. Here is a suggestion for moving the staging configuration to the `sdkInitialize()` method instead, it would save us both time and confusion.