### PR TITLE
Update the id token

### DIFF
--- a/connect/src/com/telenor/connect/id/ConnectIdService.java
+++ b/connect/src/com/telenor/connect/id/ConnectIdService.java
@@ -239,7 +239,7 @@ public class ConnectIdService {
                                 = HeadersDateUtil.extractDate(response.getHeaders());
                         ConnectTokens connectTokens
                                 = new ConnectTokens(connectTokensTO, serverTimestamp);
-                        connectStore.update(connectTokens);
+                        connectStore.set(connectTokens);
                         currentTokens = connectTokens;
                         callback.onSuccess(connectTokens.getAccessToken());
                     }

--- a/connect/src/com/telenor/connect/id/ConnectStore.java
+++ b/connect/src/com/telenor/connect/id/ConnectStore.java
@@ -84,15 +84,6 @@ public class ConnectStore {
                 .apply();
     }
 
-    public void update(ConnectTokens connectTokens) {
-        String jsonConnectTokens = preferencesGson.toJson(connectTokens);
-        context
-                .getSharedPreferences(PREFERENCES_FILE, Context.MODE_PRIVATE)
-                .edit()
-                .putString(PREFERENCE_KEY_CONNECT_TOKENS, jsonConnectTokens)
-                .apply();
-    }
-
     public ConnectTokens get() {
         String connectTokensJson = context
                 .getSharedPreferences(PREFERENCES_FILE, Context.MODE_PRIVATE)


### PR DESCRIPTION
Always update the locally stored id token when a new one is received.

The ConnectStore.update() method becomes identical to the ConnectStore.set() method when we always update the id token, so we only need the set() method.