### PR TITLE
Update to Retrofit 2

### DIFF
--- a/connect-id-example/proguard-rules.pro
+++ b/connect-id-example/proguard-rules.pro
@@ -1,43 +1,35 @@
 # Connect SDK
 -keep class com.telenor.** { *; }
 
-# Retrofit 1.X
--keep class com.squareup.okhttp.** { *; }
--keep class retrofit.** { *; }
--keep interface com.squareup.okhttp.** { *; }
+# Retrofit 2: https://github.com/square/retrofit#r8--proguard
+# Retain generic type information for use by reflection by converters and adapters.
+-keepattributes Signature
 
--dontwarn com.squareup.okhttp.**
--dontwarn okio.**
--dontwarn retrofit.**
--dontwarn rx.**
-
--keepclasseswithmembers class * {
-    @retrofit.http.* <methods>;
+# Retain service method parameters.
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
 }
 
-# If in your rest service interface you use methods with Callback argument.
--keepattributes Exceptions
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
-# If your rest service methods throw custom exceptions, because you've defined an ErrorHandler.
--keepattributes Signature
+# OkHttp 3: https://github.com/square/okhttp#proguard
+# Okio: https://github.com/square/okio#proguard
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-dontwarn javax.annotation.**
+-dontwarn org.conscrypt.**
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
 
 # Also you must note that if you are using GSON for conversion from JSON to POJO representation, you must ignore those POJO classes from being obfuscated.
 # Here include the POJO's that have you have created for mapping JSON response to POJO for example.
 
-
-# OkHttp
--keepattributes Signature
+# GSON: https://github.com/google/gson/blob/master/examples/android-proguard-example/proguard.cfg
+# For using GSON @Expose annotation
 -keepattributes *Annotation*
--keep class okhttp3.** { *; }
--keep interface okhttp3.** { *; }
--dontwarn okhttp3.**
+# Gson specific classes
+-dontwarn sun.misc.**
 
 # bouncycastle
 -dontwarn org.bouncycastle.**
-
-# Okio
--keep class sun.misc.Unsafe { *; }
--keep class okio.** { *; }
--dontwarn java.nio.file.*
--dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
--dontwarn okio.**

--- a/connect/build.gradle
+++ b/connect/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     api 'com.google.android.gms:play-services-ads-identifier:15.0.1'
     api 'com.google.android.gms:play-services-base:15.0.1'
     api 'com.nimbusds:nimbus-jose-jwt:3.10'
-    api 'com.squareup.okhttp3:okhttp:3.10.0'
-    api 'com.squareup.okhttp3:logging-interceptor:3.10.0'
+    api 'com.squareup.okhttp3:okhttp:3.11.0'
+    api 'com.squareup.okhttp3:logging-interceptor:3.11.0'
     api 'com.squareup.retrofit2:retrofit:2.4.0'
     api 'com.squareup.retrofit2:converter-gson:2.4.0'
 }

--- a/connect/build.gradle
+++ b/connect/build.gradle
@@ -35,14 +35,15 @@ android {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:27.1.1'
-    compile 'com.squareup.retrofit:retrofit:1.9.0'
-    compile 'com.squareup.okhttp3:okhttp:3.8.1'
-    compile 'com.nimbusds:nimbus-jose-jwt:3.10'
     compile 'com.android.support:customtabs:27.1.1'
-    compile 'com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0'
     compile 'com.android.support:support-v4:27.1.1'
     compile 'com.google.android.gms:play-services-ads-identifier:15.0.1'
     compile 'com.google.android.gms:play-services-base:15.0.1'
+    compile 'com.nimbusds:nimbus-jose-jwt:3.10'
+    compile 'com.squareup.okhttp3:okhttp:3.10.0'
+    compile 'com.squareup.okhttp3:logging-interceptor:3.10.0'
+    compile 'com.squareup.retrofit2:retrofit:2.4.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.4.0'
 }
 
 publish {

--- a/connect/src/com/telenor/connect/AnalyticsAPI.java
+++ b/connect/src/com/telenor/connect/AnalyticsAPI.java
@@ -4,12 +4,11 @@ import android.os.Build;
 
 import com.google.gson.annotations.SerializedName;
 
-import retrofit.Callback;
-import retrofit.ResponseCallback;
-import retrofit.http.Body;
-import retrofit.http.Header;
-import retrofit.http.Headers;
-import retrofit.http.POST;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.Header;
+import retrofit2.http.Headers;
+import retrofit2.http.POST;
 
 public interface AnalyticsAPI {
     class SDKAnalyticsData {
@@ -84,8 +83,7 @@ public interface AnalyticsAPI {
 
     @Headers("Content-Type: application/json")
     @POST("/V1/android")
-    void sendAnalyticsData(
+    Call<Void> sendAnalyticsData(
             @Header("Authorization") String auth,
-            @Body SDKAnalyticsData analyticsData,
-            ResponseCallback callback);
+            @Body SDKAnalyticsData analyticsData);
 }

--- a/connect/src/com/telenor/connect/AnalyticsAPI.java
+++ b/connect/src/com/telenor/connect/AnalyticsAPI.java
@@ -82,7 +82,7 @@ public interface AnalyticsAPI {
     }
 
     @Headers("Content-Type: application/json")
-    @POST("/V1/android")
+    @POST("V1/android")
     Call<Void> sendAnalyticsData(
             @Header("Authorization") String auth,
             @Body SDKAnalyticsData analyticsData);

--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -345,7 +345,7 @@ public final class ConnectSdk {
                 clientId,
                 redirectUri);
         RestHelper.
-                getWellKnownApi(ConnectUrlHelper.getWellKnownEndpoint()).getWellKnownConfig()
+                getWellKnownApi(ConnectUrlHelper.getConnectApiUrl().toString()).getWellKnownConfig()
                 .enqueue(new Callback<WellKnownAPI.WellKnownConfig>() {
                     @Override
                     public void onResponse(Call<WellKnownAPI.WellKnownConfig> call,

--- a/connect/src/com/telenor/connect/WellKnownAPI.java
+++ b/connect/src/com/telenor/connect/WellKnownAPI.java
@@ -9,17 +9,17 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import retrofit.Callback;
-import retrofit.http.GET;
-import retrofit.http.Headers;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Headers;
 
 public interface WellKnownAPI {
 
-    public static final String OPENID_CONFIGURATION_PATH = "/.well-known/openid-configuration";
+    String OPENID_CONFIGURATION_PATH = ".well-known/openid-configuration/";
 
     @Headers("Content-Type: application/json")
     @GET("/")
-    void getWellKnownConfig(Callback<WellKnownConfig> callback);
+    Call<WellKnownConfig> getWellKnownConfig();
 
     class WellKnownConfig implements Parcelable {
 

--- a/connect/src/com/telenor/connect/WellKnownAPI.java
+++ b/connect/src/com/telenor/connect/WellKnownAPI.java
@@ -98,6 +98,14 @@ public interface WellKnownAPI {
         @SerializedName("telenordigital_sdk_analytics_endpoint")
         private String analyticsEndpoint;
         public String getAnalyticsEndpoint() {
+            if (analyticsEndpoint != null) {
+                try {
+                    if ('/' != analyticsEndpoint.charAt(analyticsEndpoint.length() - 1)) {
+                        return analyticsEndpoint + "/";
+                    }
+                } catch (IndexOutOfBoundsException ignored) {
+                }
+            }
             return analyticsEndpoint;
         }
     }

--- a/connect/src/com/telenor/connect/WellKnownAPI.java
+++ b/connect/src/com/telenor/connect/WellKnownAPI.java
@@ -15,10 +15,8 @@ import retrofit2.http.Headers;
 
 public interface WellKnownAPI {
 
-    String OPENID_CONFIGURATION_PATH = ".well-known/openid-configuration/";
-
     @Headers("Content-Type: application/json")
-    @GET("/")
+    @GET("/oauth/.well-known/openid-configuration")
     Call<WellKnownConfig> getWellKnownConfig();
 
     class WellKnownConfig implements Parcelable {

--- a/connect/src/com/telenor/connect/id/ConnectAPI.java
+++ b/connect/src/com/telenor/connect/id/ConnectAPI.java
@@ -1,48 +1,44 @@
 package com.telenor.connect.id;
 
-import retrofit.Callback;
-import retrofit.ResponseCallback;
-import retrofit.http.Field;
-import retrofit.http.FormUrlEncoded;
-import retrofit.http.GET;
-import retrofit.http.Header;
-import retrofit.http.Headers;
-import retrofit.http.POST;
+import retrofit2.Call;
+import retrofit2.http.Field;
+import retrofit2.http.FormUrlEncoded;
+import retrofit2.http.GET;
+import retrofit2.http.Header;
+import retrofit2.http.Headers;
+import retrofit2.http.POST;
 
 public interface ConnectAPI {
 
     @FormUrlEncoded
     @Headers("Content-Type: application/x-www-form-urlencoded")
     @POST("/oauth/token")
-    void getAccessTokens(
+    Call<ConnectTokensTO> getAccessTokens(
             @Field("grant_type") String grant_type,
             @Field("code") String code,
             @Field("redirect_uri") String redirect_uri,
-            @Field("client_id") String client_id,
-            Callback<ConnectTokensTO> tokens);
+            @Field("client_id") String client_id);
 
     @FormUrlEncoded
     @Headers("Content-Type: application/x-www-form-urlencoded")
     @POST("/oauth/token")
-    void refreshAccessTokens(
+    Call<ConnectTokensTO> refreshAccessTokens(
             @Field("grant_type") String grant_type,
             @Field("refresh_token") String refresh_token,
-            @Field("client_id") String client_id,
-            Callback<ConnectTokensTO> tokens);
+            @Field("client_id") String client_id);
 
     @FormUrlEncoded
     @Headers("Content-Type: application/x-www-form-urlencoded")
     @POST("/oauth/revoke")
-    void revokeToken(
+    Call<Void> revokeToken(
             @Field("client_id") String client_id,
-            @Field("token") String token,
-            ResponseCallback callback);
+            @Field("token") String token);
 
     @Headers("Content-Type: application/x-www-form-urlencoded")
     @POST("/oauth/logout")
-    void logOut(@Header("Authorization") String auth, ResponseCallback callback);
+    Call<Void> logOut(@Header("Authorization") String auth);
 
     @Headers("Accept: application/json")
     @GET("/oauth/userinfo")
-    void getUserInfo(@Header("Authorization") String auth, Callback<UserInfo> userInfoCallback);
+    Call<UserInfo> getUserInfo(@Header("Authorization") String auth);
 }

--- a/connect/src/com/telenor/connect/id/ConnectIdService.java
+++ b/connect/src/com/telenor/connect/id/ConnectIdService.java
@@ -17,10 +17,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import retrofit.Callback;
-import retrofit.ResponseCallback;
-import retrofit.RetrofitError;
-import retrofit.client.Response;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class ConnectIdService {
 
@@ -80,26 +79,31 @@ public class ConnectIdService {
                 "authorization_code",
                 authCode,
                 redirectUrl,
-                clientId,
-                new Callback<ConnectTokensTO>() {
+                clientId)
+                .enqueue(new Callback<ConnectTokensTO>() {
                     @Override
-                    public void success(ConnectTokensTO connectTokensTO, Response response) {
-                        Date serverTimestamp
-                                = HeadersDateUtil.extractDate(response.getHeaders());
-                        ConnectTokens connectTokens
-                                = new ConnectTokens(connectTokensTO, serverTimestamp);
-                        connectStore.set(connectTokens);
-                        connectStore.clearSessionStateParam();
-                        currentTokens = connectTokens;
-                        idToken = connectTokens.getIdToken();
-                        ConnectUtils.sendTokenStateChanged(true);
-                        if (callback != null) {
-                            callback.onSuccess(connectTokens);
+                    public void onResponse(Call<ConnectTokensTO> call, Response<ConnectTokensTO> response) {
+                        if (response.isSuccessful()) {
+                            Date serverTimestamp = HeadersDateUtil.extractDate(response.headers());
+                            ConnectTokens connectTokens = new ConnectTokens(response.body(), serverTimestamp);
+                            connectStore.set(connectTokens);
+                            connectStore.clearSessionStateParam();
+                            currentTokens = connectTokens;
+                            idToken = connectTokens.getIdToken();
+                            ConnectUtils.sendTokenStateChanged(true);
+                            if (callback != null) {
+                                callback.onSuccess(connectTokens);
+                            }
+                        } else {
+                            clearTokensAndNotify();
+                            if (callback != null) {
+                                callback.onError(null);
+                            }
                         }
                     }
 
                     @Override
-                    public void failure(RetrofitError error) {
+                    public void onFailure(Call<ConnectTokensTO> call, Throwable error) {
                         clearTokensAndNotify();
                         if (callback != null) {
                             Map<String, String> errorParams = new HashMap<>();
@@ -151,14 +155,18 @@ public class ConnectIdService {
     private void revokeToken(final String token, final String descriptor) {
         connectApi.revokeToken(
                 clientId,
-                token,
-                new ResponseCallback() {
+                token)
+                .enqueue(new Callback<Void>() {
                     @Override
-                    public void success(Response response) {
+                    public void onResponse(Call<Void> call, Response<Void> response) {
+                        if (!response.isSuccessful()) {
+                            Log.e(ConnectUtils.LOG_TAG, "Failed to call revoke " + descriptor +
+                                    " token on API. token=" + token);
+                        }
                     }
 
                     @Override
-                    public void failure(RetrofitError error) {
+                    public void onFailure(Call<Void> call, Throwable error) {
                         Log.e(ConnectUtils.LOG_TAG, "Failed to call revoke " + descriptor +
                                 " token on API. token=" + token , error);
                     }
@@ -211,14 +219,19 @@ public class ConnectIdService {
 
     private void callLogOutApiEndpoint(final String accessToken, final ConnectCallback callback) {
         String auth = "Bearer " + accessToken;
-        connectApi.logOut(auth, new ResponseCallback() {
+        connectApi.logOut(auth).enqueue(new Callback<Void>() {
             @Override
-            public void success(Response response) {
-                callback.onSuccess(null);
+            public void onResponse(Call<Void> call, Response<Void> response) {
+                if (response.isSuccessful()) {
+                    callback.onSuccess(null);
+                } else {
+                    Log.e(ConnectUtils.LOG_TAG, "Failed to call logout with access token on API. accessToken=" + accessToken);
+                    callback.onError(null);
+                }
             }
 
             @Override
-            public void failure(RetrofitError error) {
+            public void onFailure(Call<Void> call, Throwable error) {
                 Log.e(ConnectUtils.LOG_TAG, "Failed to call logout with access token on API. accessToken=" + accessToken , error);
                 callback.onError(error);
             }
@@ -232,26 +245,25 @@ public class ConnectIdService {
                     "can't update tokens.");
         }
         connectApi.refreshAccessTokens("refresh_token", refreshToken,
-                clientId, new Callback<ConnectTokensTO>() {
+                clientId).enqueue(new Callback<ConnectTokensTO>() {
                     @Override
-                    public void success(ConnectTokensTO connectTokensTO, Response response) {
-                        Date serverTimestamp
-                                = HeadersDateUtil.extractDate(response.getHeaders());
-                        ConnectTokens connectTokens
-                                = new ConnectTokens(connectTokensTO, serverTimestamp);
-                        connectStore.update(connectTokens);
-                        currentTokens = connectTokens;
-                        callback.onSuccess(connectTokens.getAccessToken());
+                    public void onResponse(Call<ConnectTokensTO> call, Response<ConnectTokensTO> response) {
+                        if (response.isSuccessful()) {
+                            Date serverTimestamp = HeadersDateUtil.extractDate(response.headers());
+                            ConnectTokens connectTokens = new ConnectTokens(response.body(), serverTimestamp);
+                            connectStore.update(connectTokens);
+                            currentTokens = connectTokens;
+                            callback.onSuccess(connectTokens.getAccessToken());
+                        } else {
+                            if (response.code() >= 400 && response.code() < 500) {
+                                clearTokensAndNotify();
+                            }
+                            callback.onError(null);
+                        }
                     }
 
                     @Override
-                    public void failure(RetrofitError error) {
-                        if (error != null
-                                && error.getResponse() != null
-                                && error.getResponse().getStatus() >= 400
-                                && error.getResponse().getStatus() < 500) {
-                            clearTokensAndNotify();
-                        }
+                    public void onFailure(Call<ConnectTokensTO> call, Throwable error) {
                         callback.onError(error);
                     }
                 });
@@ -279,6 +291,6 @@ public class ConnectIdService {
                     "No user is signed in. accessToken="+accessToken);
         }
         final String auth = "Bearer " + accessToken;
-        connectApi.getUserInfo(auth, userInfoCallback);
+        connectApi.getUserInfo(auth).enqueue(userInfoCallback);
     }
 }

--- a/connect/src/com/telenor/connect/utils/ConnectUrlHelper.java
+++ b/connect/src/com/telenor/connect/utils/ConnectUrlHelper.java
@@ -101,17 +101,13 @@ public class ConnectUrlHelper {
 
 
     public static String getWellKnownEndpoint() {
-        HttpUrl.Builder builder = ConnectUrlHelper.getConnectApiUrl().newBuilder();
-        builder.addPathSegment(OAUTH_PATH);
-        for (String pathSegment : WellKnownAPI.OPENID_CONFIGURATION_PATH.split("/")) {
-            if (!TextUtils.isEmpty(pathSegment)) {
-                builder.addPathSegment(pathSegment);
-            }
-        }
-        final String wellKnownEndpoint = builder.build().toString();
-        return !ConnectSdk.useStaging()
-                ? wellKnownEndpoint
-                : wellKnownEndpoint.replace(
-                "connect.telenordigital.com", "connect.staging.telenordigital.com");
+        return ConnectUrlHelper.getConnectApiUrl().newBuilder()
+                .host(ConnectSdk.useStaging()
+                        ? "connect.staging.telenordigital.com"
+                        : "connect.telenordigital.com")
+                .addPathSegment(OAUTH_PATH)
+                .addPathSegments(WellKnownAPI.OPENID_CONFIGURATION_PATH)
+                .build()
+                .toString();
     }
 }

--- a/connect/src/com/telenor/connect/utils/ConnectUrlHelper.java
+++ b/connect/src/com/telenor/connect/utils/ConnectUrlHelper.java
@@ -9,7 +9,6 @@ import com.telenor.connect.BrowserType;
 import com.telenor.connect.BuildConfig;
 import com.telenor.connect.ConnectException;
 import com.telenor.connect.ConnectSdk;
-import com.telenor.connect.WellKnownAPI;
 
 import java.util.HashMap;
 import java.util.List;
@@ -97,17 +96,5 @@ public class ConnectUrlHelper {
                 BuildConfig.VERSION_NAME,
                 Build.VERSION.RELEASE,
                 browserType != null ? browserType.getVersionString() : "not-defined");
-    }
-
-
-    public static String getWellKnownEndpoint() {
-        return ConnectUrlHelper.getConnectApiUrl().newBuilder()
-                .host(ConnectSdk.useStaging()
-                        ? "connect.staging.telenordigital.com"
-                        : "connect.telenordigital.com")
-                .addPathSegment(OAUTH_PATH)
-                .addPathSegments(WellKnownAPI.OPENID_CONFIGURATION_PATH)
-                .build()
-                .toString();
     }
 }

--- a/connect/src/com/telenor/connect/utils/HeadersDateUtil.java
+++ b/connect/src/com/telenor/connect/utils/HeadersDateUtil.java
@@ -8,10 +8,9 @@ import android.util.Log;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.List;
 import java.util.Locale;
 
-import retrofit.client.Header;
+import okhttp3.Headers;
 
 public class HeadersDateUtil {
 
@@ -20,11 +19,11 @@ public class HeadersDateUtil {
             = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
 
     @Nullable
-    public static Date extractDate(@NonNull List<Header> headers) {
-        for (Header header : headers) {
-            if (header.getName().equalsIgnoreCase("Date")) {
+    public static Date extractDate(@NonNull Headers headers) {
+        for (String name : headers.names()) {
+            if ("Date".equalsIgnoreCase(name)) {
                 try {
-                    return DATE_FORMAT.parse(header.getValue());
+                    return DATE_FORMAT.parse(headers.get(name));
                 } catch (ParseException e) {
                     Log.w(ConnectUtils.LOG_TAG, "Failed to call parse Date from headers. " +
                             "headers=" + headers, e);

--- a/connect/tests/src/test/java/com/telenor/TestHelper.java
+++ b/connect/tests/src/test/java/com/telenor/TestHelper.java
@@ -2,28 +2,14 @@ package com.telenor;
 
 import com.telenor.connect.WellKnownAPI;
 
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.robolectric.Robolectric;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import retrofit.Callback;
-
-import static com.telenor.connect.WellKnownAPI.WellKnownConfig;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-
 public class TestHelper {
 
-    public static final String DUMMY_ISSUER = "https://dummy/oauth";
     public static final Map<String, WellKnownAPI> WELL_KNOWN_API_MAP = new HashMap<>();
-    public static final String
-            MOCKED_WELL_KNOWN_ENDPONT = DUMMY_ISSUER + "/.well-known/openid-configuration";
 
     private static final long SLEEPING_TIME_IN_MILLIES = 10;
 
@@ -48,42 +34,4 @@ public class TestHelper {
         }
         return false;
     }
-
-    public static final WellKnownAPI MOCKED_FAILING_WELL_KNOWN_API = getFailingWellKnownApiMock();
-
-    public static final WellKnownAPI MOCKED_VALID_WELL_KNOWN_API = getValidWellKnownApiMock();
-
-    private static WellKnownAPI getValidWellKnownApiMock() {
-        final WellKnownConfig wellKnownConfig = mock(WellKnownConfig.class);
-        when(wellKnownConfig.getIssuer()).thenReturn(DUMMY_ISSUER);
-
-        WellKnownAPI api = mock(WellKnownAPI.class);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Callback<WellKnownConfig> callback =
-                        (Callback<WellKnownConfig>) invocation.getArguments()[0];
-                callback.success(wellKnownConfig, null);
-                return null;
-            }
-        }).when(api).getWellKnownConfig(
-                any(Callback.class));
-        return api;
-
-    }
-    private static WellKnownAPI getFailingWellKnownApiMock() {
-        WellKnownAPI api = mock(WellKnownAPI.class);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Callback<WellKnownAPI.WellKnownConfig> callback =
-                        (Callback<WellKnownAPI.WellKnownConfig>) invocation.getArguments()[0];
-                callback.failure(null);
-                return null;
-            }
-        }).when(api).getWellKnownConfig(any(Callback.class));
-        return api;
-    }
-
-
 }

--- a/connect/tests/src/test/java/com/telenor/connect/id/ConnectIdServiceTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/id/ConnectIdServiceTest.java
@@ -13,7 +13,7 @@ import org.robolectric.annotation.Config;
 
 import java.util.Date;
 
-import retrofit.Callback;
+import retrofit2.Call;
 
 import static junit.framework.Assert.fail;
 import static org.hamcrest.CoreMatchers.is;
@@ -81,10 +81,12 @@ public class ConnectIdServiceTest {
         when(connectStore.get()).thenReturn(connectTokens);
 
         ConnectAPI connectApi = mock(ConnectAPI.class);
+        Call call = mock(Call.class);
+        when(connectApi.getUserInfo(anyString())).thenReturn(call);
         ConnectIdService connectIdService = new ConnectIdService(connectStore, connectApi, "", "");
 
         connectIdService.getUserInfo(null);
-        verify(connectApi).getUserInfo("Bearer access token", null);
+        verify(connectApi).getUserInfo("Bearer access token");
     }
 
     @Test(expected = ConnectRefreshTokenMissingException.class)
@@ -114,6 +116,9 @@ public class ConnectIdServiceTest {
         when(connectStore.get()).thenReturn(connectTokens);
 
         ConnectAPI connectApi = mock(ConnectAPI.class);
+        Call call = mock(Call.class);
+        when(connectApi.refreshAccessTokens(anyString(), anyString(), anyString()))
+                .thenReturn(call);
         ConnectIdService connectIdService = new ConnectIdService(connectStore, connectApi, "", "");
 
         connectIdService.getValidAccessToken(new AccessTokenCallback() {
@@ -128,8 +133,7 @@ public class ConnectIdServiceTest {
         verify(connectApi).refreshAccessTokens(
                 anyString(),
                 eq("refresh_token"),
-                anyString(),
-                Matchers.<Callback<ConnectTokensTO>>any());
+                anyString());
     }
 
     @Test

--- a/connect/tests/src/test/java/com/telenor/connect/utils/HeadersDateUtilTest.java
+++ b/connect/tests/src/test/java/com/telenor/connect/utils/HeadersDateUtilTest.java
@@ -3,13 +3,11 @@ package com.telenor.connect.utils;
 import org.junit.Test;
 import org.robolectric.annotation.Config;
 
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.List;
 import java.util.TimeZone;
 
-import retrofit.client.Header;
+import okhttp3.Headers;
 
 import static java.lang.Math.abs;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -25,18 +23,19 @@ public class HeadersDateUtilTest {
     }
 
     @Test
-    public void getReturnsNullOnEmptyList() {
-        Date actual = HeadersDateUtil.extractDate(new ArrayList<Header>());
+    public void getReturnsNullOnEmpty() {
+        Date actual = HeadersDateUtil.extractDate(new Headers.Builder().build());
 
         assertThat(actual, is(nullValue()));
     }
 
     @Test
-    public void getReturnsDateObjectWhenPresentInList() {
-        List<Header> headers = new ArrayList<>();
-        headers.add(new Header("Something-Else", "Foo"));
-        headers.add(new Header("Not-Date", "Tue, 15 Nov 1264 08:12:31 GMT"));
-        headers.add(new Header("Date", "Tue, 15 Nov 1994 08:12:31 GMT"));
+    public void getReturnsDateObjectWhenPresent() {
+        Headers headers = new Headers.Builder()
+                .add("Something-Else", "Foo")
+                .add("Not-Date", "Tue, 15 Nov 1264 08:12:31 GMT")
+                .add("Date", "Tue, 15 Nov 1994 08:12:31 GMT")
+                .build();
 
         Date actual = HeadersDateUtil.extractDate(headers);
 


### PR DESCRIPTION
Hi, here's a suggestion for updating to Retrofit 2. See  #127
We're using Retrofit 2 in our app and it would be great if the Connect SDK uses the same.

The biggest change is that the Retrofit interfaces returns `Call<T>` objects and we now pass in callbacks to `call.enqueue()`. We also get error status codes in `onResponse` and have to check `response.isSuccessful()` there.

I've tried to keep the diff minimal, so I may not have formatted the code perfectly.

Example ProGuard rules are updated according to documentation for each library.

The WellKnownAPI mock methods in TestHelper are removed because they were unused and I don't know how to make them work with Retrofit 2.

I tested this with our app and it seems to work fine, but obviously it needs testing from you.