### PR TITLE
Fix updateTokens noSignedInUser bug

### DIFF
--- a/connect/src/com/telenor/connect/id/ConnectIdService.java
+++ b/connect/src/com/telenor/connect/id/ConnectIdService.java
@@ -256,6 +256,7 @@ public class ConnectIdService {
         final String refreshToken = getRefreshToken();
         if (refreshToken == null) {
             callback.noSignedInUser();
+            return;
         }
         connectApi.refreshAccessTokens("refresh_token", refreshToken,
                 clientId).enqueue(new Callback<ConnectTokensTO>() {


### PR DESCRIPTION
When calling ConnectSdk.updateTokens(callback) it would correctly call
callback.noSignedInUser, but incorrectly continue execution (with an
empty refresh token). This commit fixes that.