### PR TITLE
Generate new logSessionId in more scenarios

### DIFF
--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -61,6 +61,7 @@ import retrofit2.Callback;
 import retrofit2.Response;
 
 public final class ConnectSdk {
+    public static final int SESSION_TIMEOUT_MINUTES = 10;
     private static ArrayList<Locale> sLocales;
     private static ConnectStore connectStore;
     private static WellKnownConfigStore lastSeenWellKnownConfigStore;
@@ -125,12 +126,16 @@ public final class ConnectSdk {
     }
 
     private static void updateLogSessionIdIfTooOld() {
-        Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.MINUTE, -10);
-        Date _10MinutesAgo = calendar.getTime();
+        Date _10MinutesAgo = getSessionTimeoutDate();
         if (logSessionIdSetTime.before(_10MinutesAgo)) {
             setRandomLogSessionId();
         }
+    }
+
+    private static Date getSessionTimeoutDate() {
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.MINUTE, -SESSION_TIMEOUT_MINUTES);
+        return calendar.getTime();
     }
 
     private static Uri getAuthorizeUri(Map<String, String> parameters, BrowserType browserType) {

--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -61,7 +61,7 @@ import retrofit2.Callback;
 import retrofit2.Response;
 
 public final class ConnectSdk {
-    public static final int SESSION_TIMEOUT_MINUTES = 10;
+    private static final int SESSION_TIMEOUT_MINUTES = 10;
     private static ArrayList<Locale> sLocales;
     private static ConnectStore connectStore;
     private static WellKnownConfigStore lastSeenWellKnownConfigStore;

--- a/connect/src/com/telenor/connect/ui/ConnectActivity.java
+++ b/connect/src/com/telenor/connect/ui/ConnectActivity.java
@@ -88,6 +88,7 @@ public class ConnectActivity extends FragmentActivity implements ConnectCallback
 
     @Override
     public void onError(Object errorData) {
+        ConnectSdk.setRandomLogSessionId();
         Intent intent = new Intent();
         Map<String, String> authCodeData = (Map<String, String>) errorData;
         for (Map.Entry<String, String> entry : authCodeData.entrySet()) {

--- a/connect/src/com/telenor/connect/ui/ConnectCustomTabLoginButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectCustomTabLoginButton.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.customtabs.CustomTabsCallback;
 import android.support.customtabs.CustomTabsClient;
 import android.support.customtabs.CustomTabsServiceConnection;
@@ -111,6 +112,15 @@ public class ConnectCustomTabLoginButton extends ConnectWebViewLoginButton {
         }
         if (connection != null) {
             connection = null;
+        }
+    }
+
+    @Override
+    protected void onVisibilityChanged(@NonNull View changedView, int visibility) {
+        super.onVisibilityChanged(changedView, visibility);
+        Intent intent = getActivity().getIntent();
+        if (ConnectSdk.hasErrorRedirectUrlCall(intent)) {
+            ConnectSdk.setRandomLogSessionId();
         }
     }
 


### PR DESCRIPTION
Will now generate a new logSessionId on aborts, old sessions, and all
success scenarios (even when we fail to send analytics).