### PR TITLE
Fix SmsBroadcastReceiver leaking activity

### DIFF
--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -156,7 +156,7 @@ public final class ConnectSdk {
                 if (pin == null) {
                     return;
                 }
-                getContext().unregisterReceiver(smsBroadcastReceiver);
+                safeUnregisterAndRemoveBroadcastReceiver();
                 String url = ConnectUrlHelper.getSubmitPinUrl(pin);
                 Uri uri = Uri.parse(url);
                 launchUrlInCustomTab(activity, session, uri);
@@ -665,12 +665,18 @@ public final class ConnectSdk {
         if (!hasValidRedirectUrlCall(intent)) {
             return;
         }
-        if (smsBroadcastReceiver != null) {
-            getContext().unregisterReceiver(smsBroadcastReceiver);
-            smsBroadcastReceiver = null;
-        }
+        safeUnregisterAndRemoveBroadcastReceiver();
         final String code = getCodeFromIntent(intent);
         getAccessTokenFromCode(code, callback);
+    }
+
+    private static void safeUnregisterAndRemoveBroadcastReceiver() {
+        try {
+            getContext().unregisterReceiver(smsBroadcastReceiver);
+        } catch (IllegalArgumentException ignored) {
+        } finally {
+            smsBroadcastReceiver = null;
+        }
     }
 
     /**

--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -665,6 +665,10 @@ public final class ConnectSdk {
         if (!hasValidRedirectUrlCall(intent)) {
             return;
         }
+        if (smsBroadcastReceiver != null) {
+            getContext().unregisterReceiver(smsBroadcastReceiver);
+            smsBroadcastReceiver = null;
+        }
         final String code = getCodeFromIntent(intent);
         getAccessTokenFromCode(code, callback);
     }


### PR DESCRIPTION
We get an activity leak when we login with ChromeCustomTab in SDK 1.9.5. Possibly related to #145 

> com.telenor.app.mytelenor.ui.LoginActivity has leaked:
> thread Thread.!(<Java Local>)! (named 'Answers Events Handler1')
> ↳ static ExecutorUtils$1$1.!($class$dexCache)!
> ↳ DexCache.!(runtimeInternalObjects)!
> ↳ array Object[].!([1376])!
> ↳ static ConnectSdk.!(smsBroadcastReceiver)!
> ↳ SmsBroadcastReceiver.!(smsHandler)!
> ↳ ConnectSdk$2.!(val$activity)! (anonymous implementation of com.telenor.connect.sms.SmsHandler)
> ↳ LoginActivity

It looks like smsBroadcastReceiver is only unregistered if an SMS is received?
https://github.com/telenordigital/connect-android-sdk/blob/master/connect/src/com/telenor/connect/ConnectSdk.java#L152-L165

I'm not sure it is the best solution but unregistering/clearing smsBroadcastReceiver after successful login seems to fix the leak.