### PR TITLE
Fix SDK button crashes if it's in "invisible" or "gone" state in Android 5

### DIFF
--- a/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectLoginButton.java
@@ -122,6 +122,9 @@ public class ConnectLoginButton extends RelativeLayout
     @Override
     protected void onVisibilityChanged(@NonNull View changedView, int visibility) {
         super.onVisibilityChanged(changedView, visibility);
+        if (loginButton == null || loginButton.getActivity() == null) {
+            return;
+        }
         Intent intent = loginButton.getActivity().getIntent();
         boolean ongoingAuth = intent != null && ConnectSdk.hasValidRedirectUrlCall(intent);
         setLoading(ongoingAuth);


### PR DESCRIPTION
Related to https://github.com/telenordigital/connect-android-sdk/issues/166