### PR TITLE
Remove option to use fallback components directly

### DIFF
--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -39,7 +39,6 @@ import com.telenor.connect.sms.SmsPinParseUtil;
 import com.telenor.connect.sms.SmsRetrieverUtil;
 import com.telenor.connect.ui.ConnectActivity;
 import com.telenor.connect.ui.ConnectWebFragment;
-import com.telenor.connect.ui.ConnectWebViewLoginButton;
 import com.telenor.connect.utils.ConnectUrlHelper;
 import com.telenor.connect.utils.ConnectUtils;
 import com.telenor.connect.utils.TurnOnMobileDataDialogAnalytics;
@@ -63,6 +62,7 @@ import retrofit2.Callback;
 import retrofit2.Response;
 
 public final class ConnectSdk {
+    private static final int NO_CUSTOM_LAYOUT = -1;
     private static final int SESSION_TIMEOUT_MINUTES = 10;
     private static ArrayList<Locale> sLocales;
     private static ConnectStore connectStore;
@@ -212,7 +212,7 @@ public final class ConnectSdk {
             final Map<String, String> parameters,
             final int requestCode) {
         Validator.sdkInitialized();
-        authenticate(activity, parameters, ConnectWebViewLoginButton.NO_CUSTOM_LAYOUT, requestCode, null, null);
+        authenticate(activity, parameters, NO_CUSTOM_LAYOUT, requestCode, null, null);
     }
 
     public static synchronized void authenticate(final Activity activity,
@@ -230,7 +230,7 @@ public final class ConnectSdk {
             @Override
             public void done() {
                 Intent intent = getAuthIntent(parameters);
-                if (customLoadingLayout != ConnectWebViewLoginButton.NO_CUSTOM_LAYOUT) {
+                if (customLoadingLayout != NO_CUSTOM_LAYOUT) {
                     intent.putExtra(ConnectUtils.CUSTOM_LOADING_SCREEN_EXTRA, customLoadingLayout);
                 }
                 activity.startActivityForResult(intent, requestCode);

--- a/connect/src/com/telenor/connect/ui/ConnectButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectButton.java
@@ -11,7 +11,7 @@ import androidx.appcompat.widget.AppCompatButton;
 
 import com.telenor.connect.ConnectException;
 
-public class ConnectButton extends AppCompatButton implements UiComponentUtils {
+class ConnectButton extends AppCompatButton implements UiComponentUtils {
 
     public ConnectButton(final Context context, final AttributeSet attributeSet) {
         super(context, attributeSet);

--- a/connect/src/com/telenor/connect/ui/ConnectCustomTabLoginButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectCustomTabLoginButton.java
@@ -29,7 +29,7 @@ import java.lang.ref.WeakReference;
  * Uses custom tabs, unless not available. If not available falls back to ConnectWebViewLoginButton
  * logic.
  */
-public class ConnectCustomTabLoginButton extends ConnectWebViewLoginButton {
+class ConnectCustomTabLoginButton extends ConnectWebViewLoginButton {
 
     private static final Uri PRE_FETCH_URL
             = Uri.parse(

--- a/connect/src/com/telenor/connect/ui/ConnectTextView.java
+++ b/connect/src/com/telenor/connect/ui/ConnectTextView.java
@@ -11,7 +11,7 @@ import androidx.appcompat.widget.AppCompatTextView;
 
 import com.telenor.connect.ConnectException;
 
-public class ConnectTextView extends AppCompatTextView implements UiComponentUtils {
+class ConnectTextView extends AppCompatTextView implements UiComponentUtils {
 
     public ConnectTextView(final Context context, final AttributeSet attributeSet) {
         super(context, attributeSet);

--- a/connect/src/com/telenor/connect/ui/ConnectWebViewLoginButton.java
+++ b/connect/src/com/telenor/connect/ui/ConnectWebViewLoginButton.java
@@ -23,16 +23,14 @@ import java.util.Map;
 
 import androidx.annotation.NonNull;
 
-public class ConnectWebViewLoginButton extends ConnectButton implements AuthenticationButton {
-
-    public static final int NO_CUSTOM_LAYOUT = -1;
+class ConnectWebViewLoginButton extends ConnectButton implements AuthenticationButton {
 
     private ArrayList<String> acrValues;
     private Map<String, String> loginParameters;
     private ArrayList<String> loginScopeTokens;
     private int requestCode = 0xa987;
     private Claims claims;
-    private int customLoadingLayout = NO_CUSTOM_LAYOUT;
+    private int customLoadingLayout = -1;
     private ShowLoadingCallback showLoadingCallback;
     private DismissDialogCallback dismissDialogCallback;
     private OnClickListener onClickListener;


### PR DESCRIPTION
We expect SDK users to have a single entry point to the SDK
and we provide additional fallback options in case if that entry
point fails. Before it was possible to use fallback options directly,
that was allowing the usage of some bad practises. Now this option
will be disabled.

**This is a breaking change.**