### PR TITLE
Add temporary fix for HE traffic

### DIFF
--- a/connect/src/com/telenor/connect/ConnectSdk.java
+++ b/connect/src/com/telenor/connect/ConnectSdk.java
@@ -352,6 +352,7 @@ public final class ConnectSdk {
         debugInformation.put("carrierName", carrierName);
         debugInformation.put("sdkVersion", BuildConfig.VERSION_NAME);
         debugInformation.put("isAccessTokenEmpty", accessTokenIsEmpty);
+        debugInformation.put("getNumberOfNetworkTogglesCouldHappened", HeLogic.getNumberOfNetworkTogglesCouldHappened());
         if (throwable != null) {
             debugInformation.put("exception", throwable.getMessage());
             debugInformation.put("exceptionStackTrace", throwable.getStackTrace());

--- a/connect/src/com/telenor/connect/headerenrichment/HeLogic.java
+++ b/connect/src/com/telenor/connect/headerenrichment/HeLogic.java
@@ -24,6 +24,7 @@ public class HeLogic {
     private static final long HE_TOKEN_TIMEOUT_MILLISECONDS = 10_000; // Timeout is a best guess
     // at what would be long enough to succeed and short enough for users to wait it out if
     // it should fail/time out, and do a normal flow
+    private static boolean heWasInitialized = false;
     private static boolean heTokenSuccess = true;
     private static HeTokenCallback heTokenCallback;
     private static boolean isHeTokenRequestOngoing;
@@ -84,8 +85,11 @@ public class HeLogic {
                     .build();
     }
 
-    private static void initializeHeaderEnrichment(IdProvider provider, boolean useStaging, String logSessionId) {
-        if (canNotDirectNetworkTraffic) { return; }
+    private static boolean initializeHeaderEnrichment(IdProvider provider, boolean useStaging, String logSessionId) {
+        if (canNotDirectNetworkTraffic || heWasInitialized) { return false; }
+
+        // We have tried, at least.
+        heWasInitialized = true;
 
         String url = ConnectUrlHelper.getHeApiUrl(provider, useStaging, logSessionId);
         GetHeaderEnrichmentGifTask getGifTask = new GetHeaderEnrichmentGifTask(url, HE_TOKEN_TIMEOUT_MILLISECONDS) {
@@ -106,6 +110,9 @@ public class HeLogic {
             }
         };
         getGifTask.execute();
+        // At this moment we rely on handleHeTokenResult to be executed at onPostExecute
+        // or at onCancelled
+        return true;
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
@@ -155,7 +162,9 @@ public class HeLogic {
         boolean tokenIsExpired = heTokenResponse != null && new Date().after(heTokenResponse.getExpiration());
         if (heWasNeverInitialized || tokenIsExpired) {
             setFutureHeTokenCallback(parameters, showLoadingCallback, heTokenCallback, logSessionId, provider, useStaging, dismissDialogCallback);
-            initializeHeaderEnrichment(provider, useStaging, logSessionId);
+            if (!initializeHeaderEnrichment(provider, useStaging, logSessionId)) {
+                handleHeTokenResult(null);
+            }
             return;
         }
 

--- a/connect/src/com/telenor/connect/headerenrichment/HeLogic.java
+++ b/connect/src/com/telenor/connect/headerenrichment/HeLogic.java
@@ -33,6 +33,8 @@ public class HeLogic {
     private static volatile Network cellularNetwork;
     private static volatile Network defaultNetwork;
 
+    private static int numberOfNetworkTogglesCouldHappened = 0;
+
     public static void initializeNetworks(Context context, IdProvider provider, boolean useStaging) {
         connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         boolean connectivityManagerAvailableAndNotTooOldAndroid = connectivityManager != null
@@ -86,7 +88,12 @@ public class HeLogic {
     }
 
     private static boolean initializeHeaderEnrichment(IdProvider provider, boolean useStaging, String logSessionId) {
-        if (canNotDirectNetworkTraffic || heWasInitialized) { return false; }
+        if (heWasInitialized) {
+            numberOfNetworkTogglesCouldHappened++;
+        }
+        if (canNotDirectNetworkTraffic || heWasInitialized) {
+            return false;
+        }
 
         // We have tried, at least.
         heWasInitialized = true;
@@ -257,5 +264,9 @@ public class HeLogic {
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public static Network getDefaultNetwork() {
         return defaultNetwork;
+    }
+
+    public static int getNumberOfNetworkTogglesCouldHappened() {
+        return numberOfNetworkTogglesCouldHappened;
     }
 }


### PR DESCRIPTION
Now SDK is doing HE request each time when there is a network switch. That results in massive ---`prepare` and `inject` traffic towards Header Enrichment. 

This is a temporary fix for the issue, that will set the flag `heWasInitialized ` to true whenever HE prepare-inject was initialised.

Proper fix is scheduled to be done in future. It should include rewrite of network handling logic and solving threading issue while reading results from HE.